### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,6 @@
   },
   "engines": { "node": ">=0.8.0" },
   "keywords": [ "uploads", "forms", "multipart", "form-data" ],
-  "licenses": [ { "type": "MIT", "url": "http://github.com/mscdex/busboy/raw/master/LICENSE" } ],
+  "license": "MIT",
   "repository" : { "type": "git", "url": "http://github.com/mscdex/busboy.git" }
 }


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/