### PR TITLE
increase benchmark rounds to 10

### DIFF
--- a/deps/dicer/bench/dicer-bench-multipart-parser.js
+++ b/deps/dicer/bench/dicer-bench-multipart-parser.js
@@ -1,62 +1,58 @@
-var Dicer = require('../lib/Dicer'),
-    boundary = '-----------------------------168072824752491622650073',
+const Dicer = require('../lib/Dicer')
+
+for (let i = 0, il = 10; i < il; i++) {
+  const boundary = '-----------------------------168072824752491622650073',
     d = new Dicer({ boundary: boundary }),
     mb = 100,
     buffer = createMultipartBuffer(boundary, mb * 1024 * 1024),
     callbacks =
-      { partBegin: -1,
-        partEnd: -1,
-        headerField: -1,
-        headerValue: -1,
-        partData: -1,
-        end: -1,
-      };
+    {
+      partBegin: -1,
+      partEnd: -1,
+      headerField: -1,
+      headerValue: -1,
+      partData: -1,
+      end: -1,
+    };
 
 
-d.on('part', function(p) {
-  callbacks.partBegin++;
-  p.on('header', function(header) {
-    /*for (var h in header)
+  d.on('part', function (p) {
+    callbacks.partBegin++;
+    p.on('header', function (header) {
+      /*for (var h in header)
       console.log('Part header: k: ' + inspect(h) + ', v: ' + inspect(header[h]));*/
+    });
+    p.on('data', function (data) {
+      callbacks.partData++;
+      //console.log('Part data: ' + inspect(data.toString()));
+    });
+    p.on('end', function () {
+      //console.log('End of part\n');
+      callbacks.partEnd++;
+    });
   });
-  p.on('data', function(data) {
-    callbacks.partData++;
-    //console.log('Part data: ' + inspect(data.toString()));
+  d.on('end', function () {
+    //console.log('End of parts');
+    callbacks.end++;
   });
-  p.on('end', function() {
-    //console.log('End of part\n');
-    callbacks.partEnd++;
-  });
-});
-d.on('end', function() {
-  //console.log('End of parts');
-  callbacks.end++;
-});
 
-var start = +new Date(),
+  var start = +new Date(),
     nparsed = d.write(buffer),
     duration = +new Date - start,
     mbPerSec = (mb / (duration / 1000)).toFixed(2);
 
-console.log(mbPerSec+' mb/sec');
+  console.log(mbPerSec + ' mb/sec');
 
-//assert.equal(nparsed, buffer.length);
-
-function createMultipartBuffer(boundary, size) {
-  var head =
-        '--'+boundary+'\r\n'
+  function createMultipartBuffer(boundary, size) {
+    const head =
+      '--' + boundary + '\r\n'
       + 'content-disposition: form-data; name="field1"\r\n'
       + '\r\n'
-    , tail = '\r\n--'+boundary+'--\r\n'
-    , buffer = Buffer.allocUnsafe(size);
+      , tail = '\r\n--' + boundary + '--\r\n'
+      , buffer = Buffer.allocUnsafe(size);
 
-  buffer.write(head, 0, 'ascii');
-  buffer.write(tail, buffer.length - tail.length, 'ascii');
-  return buffer;
+    buffer.write(head, 0, 'ascii');
+    buffer.write(tail, buffer.length - tail.length, 'ascii');
+    return buffer;
+  }
 }
-
-process.on('exit', function() {
-  /*for (var k in callbacks) {
-    assert.equal(0, callbacks[k], k+' count off by '+callbacks[k]);
-  }*/
-});

--- a/deps/dicer/bench/dicer-bench-multipart-parser.js
+++ b/deps/dicer/bench/dicer-bench-multipart-parser.js
@@ -1,5 +1,18 @@
 const Dicer = require('../lib/Dicer')
 
+function createMultipartBuffer(boundary, size) {
+  const head =
+    '--' + boundary + '\r\n'
+    + 'content-disposition: form-data; name="field1"\r\n'
+    + '\r\n'
+    , tail = '\r\n--' + boundary + '--\r\n'
+    , buffer = Buffer.allocUnsafe(size);
+
+  buffer.write(head, 0, 'ascii');
+  buffer.write(tail, buffer.length - tail.length, 'ascii');
+  return buffer;
+}
+
 for (let i = 0, il = 10; i < il; i++) {
   const boundary = '-----------------------------168072824752491622650073',
     d = new Dicer({ boundary: boundary }),
@@ -36,23 +49,10 @@ for (let i = 0, il = 10; i < il; i++) {
     callbacks.end++;
   });
 
-  var start = +new Date(),
-    nparsed = d.write(buffer),
-    duration = +new Date - start,
-    mbPerSec = (mb / (duration / 1000)).toFixed(2);
+  const start = +new Date();
+  d.write(buffer);
+  const duration = +new Date - start;
+  const mbPerSec = (mb / (duration / 1000)).toFixed(2);
 
   console.log(mbPerSec + ' mb/sec');
-
-  function createMultipartBuffer(boundary, size) {
-    const head =
-      '--' + boundary + '\r\n'
-      + 'content-disposition: form-data; name="field1"\r\n'
-      + '\r\n'
-      , tail = '\r\n--' + boundary + '--\r\n'
-      , buffer = Buffer.allocUnsafe(size);
-
-    buffer.write(head, 0, 'ascii');
-    buffer.write(tail, buffer.length - tail.length, 'ascii');
-    return buffer;
-  }
 }


### PR DESCRIPTION
We need to increase the benchmark rounds to 10 to get realistic benchmarks. After 4 rounds it optimizes for maximum speed.

```
uzlopak@uzlopak-Lenovo-Legion-5-17ARH05H:~/Workspace/fastify/busboy$ npm run bench:dicer

> @fastify/busboy@1.0.0 bench:dicer
> node deps/dicer/bench/dicer-bench-multipart-parser.js

1515.15 mb/sec
1351.35 mb/sec
1333.33 mb/sec
2127.66 mb/sec
2127.66 mb/sec
2127.66 mb/sec
2127.66 mb/sec
2127.66 mb/sec
2173.91 mb/sec
2127.66 mb/sec
```

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
