### PR TITLE
fix inline caching deoptimization

### DIFF
--- a/deps/dicer/lib/Dicer.js
+++ b/deps/dicer/lib/Dicer.js
@@ -175,9 +175,10 @@ Dicer.prototype._oninfo = function(isMatch, data, start, end) {
     this._part._read = function(n) {
       self._unpause();
     };
-    ev = this._isPreamble ? 'preamble' : 'part';
-    if (this._events[ev])
-      this.emit(ev, this._part);
+    if (this._isPreamble && this._events['preamble'])
+      this.emit('preamble', this._part);
+    else if (this._isPreamble !== true && this._events['part'])
+      this.emit('part', this._part);
     else
       this._ignore();
     if (!this._isPreamble)

--- a/deps/dicer/lib/Dicer.js
+++ b/deps/dicer/lib/Dicer.js
@@ -139,7 +139,7 @@ Dicer.prototype._ignore = function() {
 };
 
 Dicer.prototype._oninfo = function(isMatch, data, start, end) {
-  var buf, self = this, i = 0, r, ev, shouldWriteMore = true;
+  var buf, self = this, i = 0, r, shouldWriteMore = true;
 
   if (!this._part && this._justMatched && data) {
     while (this._dashes < 2 && (start + i) < end) {


### PR DESCRIPTION
According to deoptigate, there are two inline caching issues.

![Screenshot from 2021-11-28 13-42-07](https://user-images.githubusercontent.com/5059100/143768230-1216e129-41fe-4317-a485-a42c8c4ec9e2.png)

This one fixes one of them.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
