### PR TITLE
Integrate SearchStream

### DIFF
--- a/deps/dicer/lib/Dicer.js
+++ b/deps/dicer/lib/Dicer.js
@@ -1,7 +1,7 @@
 var WritableStream = require('stream').Writable,
     inherits = require('util').inherits;
 
-var StreamSearch = require('streamsearch');
+var StreamSearch = require('../../streamsearch/sbmh');
 
 var PartStream = require('./PartStream'),
     HeaderParser = require('./HeaderParser');

--- a/deps/dicer/lib/HeaderParser.js
+++ b/deps/dicer/lib/HeaderParser.js
@@ -1,7 +1,7 @@
 var EventEmitter = require('events').EventEmitter,
     inherits = require('util').inherits;
 
-var StreamSearch = require('streamsearch');
+var StreamSearch = require('../../streamsearch/sbmh');
 
 var B_DCRLF = Buffer.from('\r\n\r\n'),
     RE_CRLF = /\r\n/g,

--- a/deps/streamsearch/sbmh.js
+++ b/deps/streamsearch/sbmh.js
@@ -36,7 +36,7 @@ function jsmemcmp(buf1, pos1, buf2, pos2, num) {
 
 function SBMH(needle) {
   if (typeof needle === 'string')
-    needle = new Buffer(needle);
+    needle = Buffer.from(needle);
   var i, j, needle_len = needle.length;
 
   this.maxMatches = Infinity;
@@ -47,7 +47,7 @@ function SBMH(needle) {
   this._needle = needle;
   this._bufpos = 0;
 
-  this._lookbehind = new Buffer(needle_len);
+  this._lookbehind = Buffer.alloc(needle_len);
 
   // Initialize occurrence table.
   for (j = 0; j < 256; ++j)
@@ -71,7 +71,7 @@ SBMH.prototype.reset = function() {
 SBMH.prototype.push = function(chunk, pos) {
   var r, chlen;
   if (!Buffer.isBuffer(chunk))
-    chunk = new Buffer(chunk, 'binary');
+    chunk = Buffer.from(chunk, 'binary');
   chlen = chunk.length;
   this._bufpos = pos || 0;
   while (r !== chlen && this.matches < this.maxMatches)

--- a/deps/streamsearch/sbmh.js
+++ b/deps/streamsearch/sbmh.js
@@ -1,0 +1,234 @@
+/**
+ * Copyright Brian White. All rights reserved.
+ * 
+ * @see https://github.com/mscdex/streamsearch
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ * 
+ * Based heavily on the Streaming Boyer-Moore-Horspool C++ implementation
+ * by Hongli Lai at: https://github.com/FooBarWidget/boyer-moore-horspool
+ */
+var EventEmitter = require('events').EventEmitter,
+    inherits = require('util').inherits;
+
+function jsmemcmp(buf1, pos1, buf2, pos2, num) {
+  for (var i = 0; i < num; ++i, ++pos1, ++pos2)
+    if (buf1[pos1] !== buf2[pos2])
+      return false;
+  return true;
+}
+
+function SBMH(needle) {
+  if (typeof needle === 'string')
+    needle = new Buffer(needle);
+  var i, j, needle_len = needle.length;
+
+  this.maxMatches = Infinity;
+  this.matches = 0;
+
+  this._occ = new Array(256);
+  this._lookbehind_size = 0;
+  this._needle = needle;
+  this._bufpos = 0;
+
+  this._lookbehind = new Buffer(needle_len);
+
+  // Initialize occurrence table.
+  for (j = 0; j < 256; ++j)
+    this._occ[j] = needle_len;
+
+  // Populate occurrence table with analysis of the needle,
+  // ignoring last letter.
+  if (needle_len >= 1) {
+    for (i = 0; i < needle_len - 1; ++i)
+      this._occ[needle[i]] = needle_len - 1 - i;
+  }
+}
+inherits(SBMH, EventEmitter);
+
+SBMH.prototype.reset = function() {
+  this._lookbehind_size = 0;
+  this.matches = 0;
+  this._bufpos = 0;
+};
+
+SBMH.prototype.push = function(chunk, pos) {
+  var r, chlen;
+  if (!Buffer.isBuffer(chunk))
+    chunk = new Buffer(chunk, 'binary');
+  chlen = chunk.length;
+  this._bufpos = pos || 0;
+  while (r !== chlen && this.matches < this.maxMatches)
+    r = this._sbmh_feed(chunk);
+  return r;
+};
+
+SBMH.prototype._sbmh_feed = function(data) {
+  var len = data.length, needle = this._needle, needle_len = needle.length;
+
+  // Positive: points to a position in `data`
+  //           pos == 3 points to data[3]
+  // Negative: points to a position in the lookbehind buffer
+  //           pos == -2 points to lookbehind[lookbehind_size - 2]
+  var pos = -this._lookbehind_size,
+      last_needle_char = needle[needle_len - 1],
+      occ = this._occ,
+      lookbehind = this._lookbehind,
+      ch;
+
+  if (pos < 0) {
+    // Lookbehind buffer is not empty. Perform Boyer-Moore-Horspool
+    // search with character lookup code that considers both the
+    // lookbehind buffer and the current round's haystack data.
+    //
+    // Loop until
+    //   there is a match.
+    // or until
+    //   we've moved past the position that requires the
+    //   lookbehind buffer. In this case we switch to the
+    //   optimized loop.
+    // or until
+    //   the character to look at lies outside the haystack.
+    while (pos < 0 && pos <= len - needle_len) {
+      ch = this._sbmh_lookup_char(data, pos + needle_len - 1);
+
+      if (ch === last_needle_char
+          && this._sbmh_memcmp(data, pos, needle_len - 1)) {
+        this._lookbehind_size = 0;
+        ++this.matches;
+        if (pos > -this._lookbehind_size)
+          this.emit('info', true, lookbehind, 0, this._lookbehind_size + pos);
+        else
+          this.emit('info', true);
+
+        return (this._bufpos = pos + needle_len);
+      } else
+        pos += occ[ch];
+    }
+
+    // No match.
+
+    if (pos < 0) {
+      // There's too few data for Boyer-Moore-Horspool to run,
+      // so let's use a different algorithm to skip as much as
+      // we can.
+      // Forward pos until
+      //   the trailing part of lookbehind + data
+      //   looks like the beginning of the needle
+      // or until
+      //   pos == 0
+      while (pos < 0 && !this._sbmh_memcmp(data, pos, len - pos))
+        pos++;
+    }
+
+    if (pos >= 0) {
+      // Discard lookbehind buffer.
+      this.emit('info', false, lookbehind, 0, this._lookbehind_size);
+      this._lookbehind_size = 0;
+    } else {
+      // Cut off part of the lookbehind buffer that has
+      // been processed and append the entire haystack
+      // into it.
+      var bytesToCutOff = this._lookbehind_size + pos;
+
+      if (bytesToCutOff > 0) {
+        // The cut off data is guaranteed not to contain the needle.
+        this.emit('info', false, lookbehind, 0, bytesToCutOff);
+      }
+
+      lookbehind.copy(lookbehind, 0, bytesToCutOff,
+                      this._lookbehind_size - bytesToCutOff);
+      this._lookbehind_size -= bytesToCutOff;
+
+      data.copy(lookbehind, this._lookbehind_size);
+      this._lookbehind_size += len;
+
+      this._bufpos = len;
+      return len;
+    }
+  }
+
+  if (pos >= 0)
+    pos += this._bufpos;
+
+  // Lookbehind buffer is now empty. Perform Boyer-Moore-Horspool
+  // search with optimized character lookup code that only considers
+  // the current round's haystack data.
+  while (pos <= len - needle_len) {
+    ch = data[pos + needle_len - 1];
+
+    if (ch === last_needle_char
+        && data[pos] === needle[0]
+        && jsmemcmp(needle, 0, data, pos, needle_len - 1)) {
+      ++this.matches;
+      if (pos > 0)
+        this.emit('info', true, data, this._bufpos, pos);
+      else
+        this.emit('info', true);
+
+      return (this._bufpos = pos + needle_len);
+    } else
+      pos += occ[ch];
+  }
+
+  // There was no match. If there's trailing haystack data that we cannot
+  // match yet using the Boyer-Moore-Horspool algorithm (because the trailing
+  // data is less than the needle size) then match using a modified
+  // algorithm that starts matching from the beginning instead of the end.
+  // Whatever trailing data is left after running this algorithm is added to
+  // the lookbehind buffer.
+  if (pos < len) {
+    while (pos < len && (data[pos] !== needle[0]
+                         || !jsmemcmp(data, pos, needle, 0, len - pos))) {
+      ++pos;
+    }
+    if (pos < len) {
+      data.copy(lookbehind, 0, pos, pos + (len - pos));
+      this._lookbehind_size = len - pos;
+    }
+  }
+
+  // Everything until pos is guaranteed not to contain needle data.
+  if (pos > 0)
+    this.emit('info', false, data, this._bufpos, pos < len ? pos : len);
+
+  this._bufpos = len;
+  return len;
+};
+
+SBMH.prototype._sbmh_lookup_char = function(data, pos) {
+  if (pos < 0)
+    return this._lookbehind[this._lookbehind_size + pos];
+  else
+    return data[pos];
+};
+
+SBMH.prototype._sbmh_memcmp = function(data, pos, len) {
+  var i = 0;
+
+  while (i < len) {
+    if (this._sbmh_lookup_char(data, pos + i) === this._needle[i])
+      ++i;
+    else
+      return false;
+  }
+  return true;
+};
+
+module.exports = SBMH;

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "lib/*",
     "deps/encoding/*",
     "deps/dicer/lib",
+    "deps/streamsearch/",
     "deps/dicer/LICENSE"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -25,9 +25,6 @@
   "engines": {
     "node": ">=10.17.0"
   },
-  "dependencies": {
-    "streamsearch": "0.1.2"
-  },
   "devDependencies": {
     "@types/node": "^16.11.10",
     "chai": "^4.3.4",

--- a/test/streamsearch.spec.js
+++ b/test/streamsearch.spec.js
@@ -1,0 +1,160 @@
+const { describe, it } = require('mocha');
+const { expect } = require('chai');
+const Streamsearch = require('../deps/streamsearch/sbmh');
+
+describe('searchstream', () => {
+
+    it('begin pos', (done) => {
+        const expected = [
+            [true, undefined, undefined, undefined],
+            [false, Buffer.from("\r\nbar hello"), 2, 11],
+        ]
+        const needle = "\r\n";
+        const s = new Streamsearch(needle);
+        const chunks = [
+            Buffer.from('\r\nbar hello'),
+        ];
+        let i = 0;
+        s.on('info', (isMatched, data, start, end) => {
+            expect(isMatched).to.be.eql(expected[i][0]);
+            expect(data).to.be.eql(expected[i][1]);
+            expect(start).to.be.eql(expected[i][2]);
+            expect(end).to.be.eql(expected[i][3]);
+            i++;
+            if (i === 2) {
+                done();
+            }
+        });
+
+        s.push(chunks[0]);
+    });
+
+    it('middle pos', (done) => {
+        const expected = [
+            [true, Buffer.from("bar\r\n hello"), 0, 3],
+            [false, Buffer.from("bar\r\n hello"), 5, 11],
+        ]
+        const needle = "\r\n";
+        const s = new Streamsearch(needle);
+        const chunks = [
+            Buffer.from('bar\r\n hello'),
+        ];
+        let i = 0;
+        s.on('info', (isMatched, data, start, end) => {
+            expect(isMatched).to.be.eql(expected[i][0]);
+            expect(data).to.be.eql(expected[i][1]);
+            expect(start).to.be.eql(expected[i][2]);
+            expect(end).to.be.eql(expected[i][3]);
+            i++;
+            if (i === 2) {
+                done();
+            }
+        });
+
+        s.push(chunks[0]);
+    });
+
+    it('end pos', (done) => {
+        const expected = [
+            [true, Buffer.from("bar hello\r\n"), 0, 9],
+        ]
+        const needle = "\r\n";
+        const s = new Streamsearch(needle);
+        const chunks = [
+            Buffer.from('bar hello\r\n'),
+        ];
+        let i = 0;
+        s.on('info', (isMatched, data, start, end) => {
+            expect(isMatched).to.be.eql(expected[i][0]);
+            expect(data).to.be.eql(expected[i][1]);
+            expect(start).to.be.eql(expected[i][2]);
+            expect(end).to.be.eql(expected[i][3]);
+            i++;
+            if (i === 1) {
+                done();
+            }
+        });
+
+        s.push(chunks[0]);
+    });
+
+    it('multiple end pos', (done) => {
+        const expected = [
+            [true, Buffer.from("bar hello\r\n\r\n"), 0, 9],
+            [true, Buffer.from("bar hello\r\n\r\n"), 11, 11],
+        ]
+        const needle = "\r\n";
+        const s = new Streamsearch(needle);
+        const chunks = [
+            Buffer.from('bar hello\r\n\r\n'),
+        ];
+        let i = 0;
+        s.on('info', (isMatched, data, start, end) => {
+            expect(isMatched).to.be.eql(expected[i][0]);
+            expect(data).to.be.eql(expected[i][1]);
+            expect(start).to.be.eql(expected[i][2]);
+            expect(end).to.be.eql(expected[i][3]);
+            i++;
+            if (i === 2) {
+                done();
+            }
+        });
+
+        s.push(chunks[0]);
+    });
+
+    it('two chunks without needle', (done) => {
+        const expected = [
+            [false, Buffer.from("bar"), 0, 3],
+            [false, Buffer.from("hello"), 0, 5],
+        ]
+        const needle = "\r\n";
+        const s = new Streamsearch(needle);
+        const chunks = [
+            Buffer.from('bar'),
+            Buffer.from('hello'),
+        ];
+        let i = 0;
+        s.on('info', (isMatched, data, start, end) => {
+            expect(isMatched).to.be.eql(expected[i][0]);
+            expect(data).to.be.eql(expected[i][1]);
+            expect(start).to.be.eql(expected[i][2]);
+            expect(end).to.be.eql(expected[i][3]);
+            i++;
+            if (i === 2) {
+                done();
+            }
+        });
+
+        s.push(chunks[0]);
+        s.push(chunks[1]);
+    });
+
+    it('two chunks with overflowing needle', (done) => {
+        const expected = [
+            [false, Buffer.from("bar\r"), 0, 3],
+            [true, undefined, undefined, undefined],
+            [false, Buffer.from("\nhello"), 1, 6],
+        ]
+        const needle = "\r\n";
+        const s = new Streamsearch(needle);
+        const chunks = [
+            Buffer.from('bar\r'),
+            Buffer.from('\nhello'),
+        ];
+        let i = 0;
+        s.on('info', (isMatched, data, start, end) => {
+            expect(isMatched).to.be.eql(expected[i][0]);
+            expect(data).to.be.eql(expected[i][1]);
+            expect(start).to.be.eql(expected[i][2]);
+            expect(end).to.be.eql(expected[i][3]);
+            i++;
+            if (i === 3) {
+                done();
+            }
+        });
+
+        s.push(chunks[0]);
+        s.push(chunks[1]);
+    });
+})


### PR DESCRIPTION
This PR integrates Searchstream package into busboy.

It also uses now Buffer.from and Buffer.allocate instead of the old constructor notation.

I also wrote unit tests for it. Seems I missed two branches.

I think the real bottle neck is this piece of code. 

The original searchstream was made for node 0.8.0. So it does not use anything which could improve the performance. The hottest parts are actually these lines

![Screenshot from 2021-11-29 10-47-52](https://user-images.githubusercontent.com/5059100/143845227-5db50f5e-87b6-4c88-928c-25c168af2760.png)

We need either optimize searchstream or replace it with a modern solution. 

By simply replacing the jsmemcmp function with Buffer.compare (which didnt exist for node 0.8.0 the benchmark looks like this:

```
> @fastify/busboy@1.0.0 bench:dicer
> node deps/dicer/bench/dicer-bench-multipart-parser.js

2500.00 mb/sec
2272.73 mb/sec
2222.22 mb/sec
3846.15 mb/sec
4000.00 mb/sec
4000.00 mb/sec
3846.15 mb/sec
4000.00 mb/sec
4000.00 mb/sec
4000.00 mb/sec
```

Before max was about 3750 mb/s

If you use references, instead of local variables it increases the performance even more.


But before we optimize it, we should integrate it. 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
