### PR TITLE
Improve code coverage for searchstream

### DIFF
--- a/test/streamsearch.spec.js
+++ b/test/streamsearch.spec.js
@@ -2,7 +2,53 @@ const { expect } = require('chai');
 const Streamsearch = require('../deps/streamsearch/sbmh');
 
 describe('streamsearch', () => {
-    it('begin pos', (done) => {
+    it('should process a Buffer without a needle', (done) => {
+        const expected = [
+            [false, Buffer.from("bar hello"), 0, 9],
+        ]
+        const needle = "\r\n";
+        const s = new Streamsearch(needle);
+        const chunks = [
+            Buffer.from('bar hello'),
+        ];
+        let i = 0;
+        s.on('info', (isMatched, data, start, end) => {
+            expect(isMatched).to.be.eql(expected[i][0]);
+            expect(data).to.be.eql(expected[i][1]);
+            expect(start).to.be.eql(expected[i][2]);
+            expect(end).to.be.eql(expected[i][3]);
+            i++;
+            if (i === 1) {
+                done();
+            }
+        });
+
+        s.push(chunks[0]);
+    });
+    it('should cast a string without a needle', (done) => {
+        const expected = [
+            [false, Buffer.from("bar hello"), 0, 9],
+        ]
+        const needle = "\r\n";
+        const s = new Streamsearch(needle);
+        const chunks = [
+            'bar hello',
+        ];
+        let i = 0;
+        s.on('info', (isMatched, data, start, end) => {
+            expect(isMatched).to.be.eql(expected[i][0]);
+            expect(data).to.be.eql(expected[i][1]);
+            expect(start).to.be.eql(expected[i][2]);
+            expect(end).to.be.eql(expected[i][3]);
+            i++;
+            if (i === 1) {
+                done();
+            }
+        });
+
+        s.push(chunks[0]);
+    });
+    it('should process a chunk with a needle at the beginning', (done) => {
         const expected = [
             [true, undefined, undefined, undefined],
             [false, Buffer.from("\r\nbar hello"), 2, 11],
@@ -27,7 +73,7 @@ describe('streamsearch', () => {
         s.push(chunks[0]);
     });
 
-    it('middle pos', (done) => {
+    it('should process a chunk with a needle in the middle', (done) => {
         const expected = [
             [true, Buffer.from("bar\r\n hello"), 0, 3],
             [false, Buffer.from("bar\r\n hello"), 5, 11],
@@ -52,7 +98,7 @@ describe('streamsearch', () => {
         s.push(chunks[0]);
     });
 
-    it('end pos', (done) => {
+    it('should process a chunk with a needle at the end', (done) => {
         const expected = [
             [true, Buffer.from("bar hello\r\n"), 0, 9],
         ]
@@ -76,7 +122,7 @@ describe('streamsearch', () => {
         s.push(chunks[0]);
     });
 
-    it('multiple end pos', (done) => {
+    it('should process a chunk with multiple needle at the end', (done) => {
         const expected = [
             [true, Buffer.from("bar hello\r\n\r\n"), 0, 9],
             [true, Buffer.from("bar hello\r\n\r\n"), 11, 11],
@@ -101,7 +147,7 @@ describe('streamsearch', () => {
         s.push(chunks[0]);
     });
 
-    it('two chunks without needle', (done) => {
+    it('should process two chunks without a needle', (done) => {
         const expected = [
             [false, Buffer.from("bar"), 0, 3],
             [false, Buffer.from("hello"), 0, 5],
@@ -128,7 +174,7 @@ describe('streamsearch', () => {
         s.push(chunks[1]);
     });
 
-    it('two chunks with overflowing needle', (done) => {
+    it('should process two chunks with an overflowing needle', (done) => {
         const expected = [
             [false, Buffer.from("bar\r"), 0, 3],
             [true, undefined, undefined, undefined],
@@ -154,5 +200,63 @@ describe('streamsearch', () => {
 
         s.push(chunks[0]);
         s.push(chunks[1]);
+    });
+
+    it('should process two chunks with a potentially overflowing needle', (done) => {
+        const expected = [
+            [false, Buffer.from("bar\r"), 0, 3],
+            [false, Buffer.from("\r\0\0"), 0, 1],
+            [false, Buffer.from("\n\r\nhello"), 0, 8],
+        ]
+        const needle = "\r\n\n";
+        const s = new Streamsearch(needle);
+        const chunks = [
+            Buffer.from('bar\r'),
+            Buffer.from('\n\r\nhello'),
+        ];
+        let i = 0;
+        s.on('info', (isMatched, data, start, end) => {
+            expect(isMatched).to.be.eql(expected[i][0]);
+            expect(data).to.be.eql(expected[i][1]);
+            expect(start).to.be.eql(expected[i][2]);
+            expect(end).to.be.eql(expected[i][3]);
+            i++;
+            if (i === 3) {
+                done();
+            }
+        });
+
+        s.push(chunks[0]);
+        s.push(chunks[1]);
+    });
+
+    it('should process three chunks with a overflowing needle', (done) => {
+        const expected = [
+            [false, Buffer.from("bar\r"), 0, 3],
+            [true, undefined, undefined, undefined],
+            [false, Buffer.from("\nhello"), 1, 6],
+        ]
+        const needle = "\r\n\n";
+        const s = new Streamsearch(needle);
+        const chunks = [
+            Buffer.from('bar\r'),
+            Buffer.from('\n'),
+            Buffer.from('\nhello'),
+        ];
+        let i = 0;
+        s.on('info', (isMatched, data, start, end) => {
+            expect(isMatched).to.be.eql(expected[i][0]);
+            expect(data).to.be.eql(expected[i][1]);
+            expect(start).to.be.eql(expected[i][2]);
+            expect(end).to.be.eql(expected[i][3]);
+            i++;
+            if (i === 3) {
+                done();
+            }
+        });
+
+        s.push(chunks[0]);
+        s.push(chunks[1]);
+        s.push(chunks[2]);
     });
 })


### PR DESCRIPTION
With this PR the test coverage of sbmh.js increases to
sbmh.js             |   95.09 |    87.03 |     100 |   94.94 

in concert with the other tests:
sbmh.js             |   98.03 |    92.59 |     100 |   97.97

Tbh, i dont know how to increase it further, as i quite dont get in which cases the other branches get hit. 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
