### PR TITLE
replace jsmemcmp with Buffer.compare

### DIFF
--- a/deps/streamsearch/sbmh.js
+++ b/deps/streamsearch/sbmh.js
@@ -169,12 +169,8 @@ SBMH.prototype._sbmh_feed = function(data) {
     if (
       ch === last_needle_char &&
       data[pos] === needle[0] &&
-      (
-        Buffer.compare(
-            needle.subarray(0, needle_len-1),
-            data.subarray(pos, pos + needle_len - 1)
-        ) === 0)
-      ) {
+      Buffer.compare(needle.subarray(0, needle_len-1), data.subarray(pos, pos + needle_len - 1)) === 0)
+     {
       ++this.matches;
       if (pos > 0)
         this.emit('info', true, data, this._bufpos, pos);

--- a/deps/streamsearch/sbmh.js
+++ b/deps/streamsearch/sbmh.js
@@ -27,13 +27,6 @@
 var EventEmitter = require('events').EventEmitter,
     inherits = require('util').inherits;
 
-function jsmemcmp(buf1, pos1, buf2, pos2, num) {
-  for (var i = 0; i < num; ++i, ++pos1, ++pos2)
-    if (buf1[pos1] !== buf2[pos2])
-      return false;
-  return true;
-}
-
 function SBMH(needle) {
   if (typeof needle === 'string')
     needle = Buffer.from(needle);
@@ -173,9 +166,15 @@ SBMH.prototype._sbmh_feed = function(data) {
   while (pos <= len - needle_len) {
     ch = data[pos + needle_len - 1];
 
-    if (ch === last_needle_char
-        && data[pos] === needle[0]
-        && jsmemcmp(needle, 0, data, pos, needle_len - 1)) {
+    if (
+      ch === last_needle_char &&
+      data[pos] === needle[0] &&
+      (
+        Buffer.compare(
+            needle.subarray(0, needle_len-1),
+            data.subarray(pos, pos + needle_len - 1)
+        ) === 0)
+      ) {
       ++this.matches;
       if (pos > 0)
         this.emit('info', true, data, this._bufpos, pos);
@@ -194,8 +193,18 @@ SBMH.prototype._sbmh_feed = function(data) {
   // Whatever trailing data is left after running this algorithm is added to
   // the lookbehind buffer.
   if (pos < len) {
-    while (pos < len && (data[pos] !== needle[0]
-                         || !jsmemcmp(data, pos, needle, 0, len - pos))) {
+    while (
+      pos < len && 
+      (
+        data[pos] !== needle[0] || 
+        (
+          (Buffer.compare(
+            data.subarray(pos, pos + len - pos),
+            needle.subarray(0, len - pos)
+          ) !== 0)
+        )
+      )
+    ) {
       ++pos;
     }
     if (pos < len) {


### PR DESCRIPTION
This should improve the performance of searchstream
before:
```
> @fastify/busboy@1.0.0 bench:dicer
> node deps/dicer/bench/dicer-bench-multipart-parser.js

2380.95 mb/sec
2325.58 mb/sec
2272.73 mb/sec
3703.70 mb/sec
3571.43 mb/sec
3703.70 mb/sec
3703.70 mb/sec
3571.43 mb/sec
3571.43 mb/sec
3571.43 mb/sec
```

after:
```
> @fastify/busboy@1.0.0 bench:dicer
> node deps/dicer/bench/dicer-bench-multipart-parser.js

2564.10 mb/sec
2222.22 mb/sec
2173.91 mb/sec
4000.00 mb/sec
4000.00 mb/sec
4000.00 mb/sec
4000.00 mb/sec
4000.00 mb/sec
4000.00 mb/sec
4000.00 mb/sec
```

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
