### PR TITLE
Improve performance in searchstream

### DIFF
--- a/deps/streamsearch/sbmh.js
+++ b/deps/streamsearch/sbmh.js
@@ -101,8 +101,10 @@ SBMH.prototype._sbmh_feed = function(data) {
     while (pos < 0 && pos <= len - needle_len) {
       ch = this._sbmh_lookup_char(data, pos + needle_len - 1);
 
-      if (ch === last_needle_char
-          && this._sbmh_memcmp(data, pos, needle_len - 1)) {
+      if (
+        ch === last_needle_char &&
+        this._sbmh_memcmp(data, pos, needle_len - 1)
+      ) {
         this._lookbehind_size = 0;
         ++this.matches;
         if (pos > 0)
@@ -111,8 +113,8 @@ SBMH.prototype._sbmh_feed = function(data) {
           this.emit('info', true);
 
         return (this._bufpos = pos + needle_len);
-      } else
-        pos += occ[ch];
+      }
+      pos += occ[ch];
     }
 
     // No match.


### PR DESCRIPTION
Unit tests are green, so I think the change provides an equivalent change. 

![Screenshot from 2021-11-29 19-10-02](https://user-images.githubusercontent.com/5059100/143920569-71a1bc60-8bd9-4467-bd84-c734dd98857a.png)

Benchmark: 
```
> @fastify/busboy@1.0.0 bench:dicer
> node deps/dicer/bench/dicer-bench-multipart-parser.js

9090.91 mb/sec
11111.11 mb/sec
10000.00 mb/sec
11111.11 mb/sec
11111.11 mb/sec
11111.11 mb/sec
12500.00 mb/sec
12500.00 mb/sec
11111.11 mb/sec
11111.11 mb/sec
```
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
