### PR TITLE
add standard and prepare for standard lint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,7 +3,8 @@ module.exports = {
     ecmaVersion: 2018,
   },
   ignorePatterns: [
-    '/bench'
+    'bench',
+    'deps/encoding',
   ],
   extends: [
     'eslint:recommended',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,9 +1,10 @@
-const warning = process.env['CI'] ? 2 : 1;
-
 module.exports = {
   parserOptions: {
     ecmaVersion: 2018,
   },
+  ignorePatterns: [
+    '/bench'
+  ],
   extends: [
     'eslint:recommended',
     'plugin:node/recommended',

--- a/deps/dicer/lib/HeaderParser.js
+++ b/deps/dicer/lib/HeaderParser.js
@@ -5,7 +5,7 @@ var StreamSearch = require('../../streamsearch/sbmh');
 
 var B_DCRLF = Buffer.from('\r\n\r\n'),
     RE_CRLF = /\r\n/g,
-    RE_HDR = /^([^:]+):[ \t]?([\x00-\xFF]+)?$/,
+    RE_HDR = /^([^:]+):[ \t]?([\x00-\xFF]+)?$/, // eslint-disable-line no-control-regex
     MAX_HEADER_PAIRS = 2000, // from node's http.js
     MAX_HEADER_SIZE = 80 * 1024; // from node's http_parser
 

--- a/deps/encoding/TextDecoder.js
+++ b/deps/encoding/TextDecoder.js
@@ -162,15 +162,6 @@ function decoderError(fatal, opt_code_point) {
 }
 
 /**
- * @param {number} code_point The code point that could not be encoded.
- * @return {number} Always throws, no value is actually returned.
- */
-function encoderError(code_point) {
-  throw new EncodingError('The code point ' + code_point +
-                          ' could not be encoded.');
-}
-
-/**
  * @param {string} label The encoding label.
  * @return {?{name:string,labels:Array.<string>}}
  */
@@ -678,17 +669,6 @@ function indexCodePointFor(pointer, index) {
     return index[pointer] || null;
 }
 
-/**
- * @param {number} code_point The |code point| to search for.
- * @param {Array.<?number>} index The |index| to search within.
- * @return {?number} The first pointer corresponding to |code point| in
- *     |index|, or null if |code point| is not in |index|.
- */
-function indexPointerFor(code_point, index) {
-  var pointer = index.indexOf(code_point);
-  return pointer === -1 ? null : pointer;
-}
-
 /** @type {Object.<string, (Array.<number>|Array.<Array.<number>>)>} */
 var indexes = require('./encoding-indexes');
 
@@ -716,29 +696,6 @@ function indexGB18030CodePointFor(pointer) {
   }
   return code_point_offset + pointer - offset;
 }
-
-/**
- * @param {number} code_point The |code point| to locate in the gb18030 index.
- * @return {number} The first pointer corresponding to |code point| in the
- *     gb18030 index.
- */
-function indexGB18030PointerFor(code_point) {
-  var /** @type {number} */ offset = 0,
-      /** @type {number} */ pointer_offset = 0,
-      /** @type {Array.<Array.<number>>} */ idx = indexes['gb18030'];
-  var i;
-  for (i = 0; i < idx.length; ++i) {
-    var entry = idx[i];
-    if (entry[1] <= code_point) {
-      offset = entry[1];
-      pointer_offset = entry[0];
-    } else {
-      break;
-    }
-  }
-  return pointer_offset + code_point - offset;
-}
-
 
 //
 // 7. API
@@ -1719,26 +1676,6 @@ name_to_encoding['utf-16le'].getDecoder = function(options) {
 // 14.5 x-user-defined
 // TODO: Implement this encoding.
 
-// NOTE: currently unused
-/**
- * @param {string} label The encoding label.
- * @param {ByteInputStream} input_stream The byte stream to test.
- */
-function detectEncoding(label, input_stream) {
-  if (input_stream.match([0xFF, 0xFE])) {
-    input_stream.offset(2);
-    return 'utf-16le';
-  }
-  if (input_stream.match([0xFE, 0xFF])) {
-    input_stream.offset(2);
-    return 'utf-16be';
-  }
-  if (input_stream.match([0xEF, 0xBB, 0xBF])) {
-    input_stream.offset(3);
-    return 'utf-8';
-  }
-  return label;
-}
 function hasEncoding(label) {
   return Object.prototype.hasOwnProperty.call(label_to_encoding, String(label).trim().toLowerCase());
 }

--- a/deps/streamsearch/sbmh.js
+++ b/deps/streamsearch/sbmh.js
@@ -36,13 +36,13 @@ function SBMH(needle) {
     throw new TypeError("The needle has to be a String or a Buffer.");
   }
 
-  const needle_len = needle.length;
+  const needleLength = needle.length;
 
-  if (needle_len === 0) {
+  if (needleLength === 0) {
     throw new Error("The needle cannot be an empty String/Buffer.");
   }
 
-  if (needle_len > 256) {
+  if (needleLength > 256) {
     throw new Error("The needle cannot have a length bigger than 256.");
   }
 
@@ -50,17 +50,17 @@ function SBMH(needle) {
   this.matches = 0;
 
   this._occ = new Array(256)
-    .fill(needle_len); // Initialize occurrence table.
+    .fill(needleLength); // Initialize occurrence table.
   this._lookbehind_size = 0;
   this._needle = needle;
   this._bufpos = 0;
 
-  this._lookbehind = Buffer.alloc(needle_len);
+  this._lookbehind = Buffer.alloc(needleLength);
 
   // Populate occurrence table with analysis of the needle,
   // ignoring last letter.
-  for (var i = 0; i < needle_len - 1; ++i)
-    this._occ[needle[i]] = needle_len - 1 - i;
+  for (var i = 0; i < needleLength - 1; ++i)
+    this._occ[needle[i]] = needleLength - 1 - i;
 }
 inherits(SBMH, EventEmitter);
 
@@ -85,8 +85,8 @@ SBMH.prototype.push = function (chunk, pos) {
 SBMH.prototype._sbmh_feed = function (data) {
   const len = data.length,
     needle = this._needle,
-    needle_len = needle.length,
-    last_needle_char = needle[needle_len - 1];
+    needleLength = needle.length,
+    lastNeedleChar = needle[needleLength - 1];
 
   // Positive: points to a position in `data`
   //           pos == 3 points to data[3]
@@ -108,18 +108,18 @@ SBMH.prototype._sbmh_feed = function (data) {
     //   optimized loop.
     // or until
     //   the character to look at lies outside the haystack.
-    while (pos < 0 && pos <= len - needle_len) {
-      ch = this._sbmh_lookup_char(data, pos + needle_len - 1);
+    while (pos < 0 && pos <= len - needleLength) {
+      ch = this._sbmh_lookup_char(data, pos + needleLength - 1);
 
       if (
-        ch === last_needle_char &&
-        this._sbmh_memcmp(data, pos, needle_len - 1)
+        ch === lastNeedleChar &&
+        this._sbmh_memcmp(data, pos, needleLength - 1)
       ) {
         this._lookbehind_size = 0;
         ++this.matches;
         this.emit('info', true);
 
-        return (this._bufpos = pos + needle_len);
+        return (this._bufpos = pos + needleLength);
       }
       pos += this._occ[ch];
     }
@@ -177,9 +177,9 @@ SBMH.prototype._sbmh_feed = function (data) {
     else
       this.emit('info', true);
 
-    return (this._bufpos = pos + needle_len);
+    return (this._bufpos = pos + needleLength);
   } else {
-    pos = len - needle_len;
+    pos = len - needleLength;
   }
 
   // There was no match. If there's trailing haystack data that we cannot

--- a/lib/main.js
+++ b/lib/main.js
@@ -79,7 +79,7 @@ Busboy.prototype._write = function(chunk, encoding, cb) {
   this._parser.write(chunk, cb);
 };
 
-var TYPES = [
+const TYPES = [
   require('./types/multipart'),
   require('./types/urlencoded'),
 ];

--- a/lib/types/multipart.js
+++ b/lib/types/multipart.js
@@ -58,13 +58,13 @@ function Multipart(boy, cfg) {
   if (typeof boundary !== 'string')
     throw new Error('Multipart: Boundary not found');
 
-  var fieldSizeLimit = getLimit(limits, 'fieldSize', 1 * 1024 * 1024),
+  const fieldSizeLimit = getLimit(limits, 'fieldSize', 1 * 1024 * 1024),
       fileSizeLimit = getLimit(limits, 'fileSize', Infinity),
       filesLimit = getLimit(limits, 'files', Infinity),
       fieldsLimit = getLimit(limits, 'fields', Infinity),
       partsLimit = getLimit(limits, 'parts', Infinity);
 
-  var nfiles = 0,
+  let nfiles = 0,
       nfields = 0,
       nends = 0,
       curFile,

--- a/lib/types/urlencoded.js
+++ b/lib/types/urlencoded.js
@@ -9,7 +9,6 @@ function UrlEncoded(boy, cfg) {
   if (!(this instanceof UrlEncoded))
     return new UrlEncoded(boy, cfg);
   var limits = cfg.limits,
-      headers = cfg.headers,
       parsedConType = cfg.parsedConType;
   this.boy = boy;
 
@@ -91,7 +90,7 @@ UrlEncoded.prototype.write = function(data, cb) {
       } else if (idxamp !== undefined) {
         // key with no assignment
         ++this._fields;
-        var key, keyTrunc = this._keyTrunc;
+        let key, keyTrunc = this._keyTrunc;
         if (idxamp > p)
           key = (this._key += this.decoder.write(data.toString('binary', p, idxamp)));
         else

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -169,20 +169,20 @@ function basename(path) {
 }
 
 function getLimit(limits, name, defaultLimit) {
-  if (!limits)
-    return defaultLimit;
+  if (
+    !limits ||
+    limits[name] === undefined ||
+    limits[name] === null
+  )
+  return defaultLimit;
 
-  var limit = limits[name];
-  // Intentional double equals
-  if (limit == undefined)
-    return defaultLimit;
+  if (
+    typeof limits[name] !== 'number' ||
+    isNaN(limits[name])
+  )
+  throw new TypeError('Limit ' + name + ' is not a valid number');
 
-  // Ensure limit is a number and is not NaN
-  if (typeof limit !== 'number' || limit !== limit) {
-    throw new Error('Limit ' + name + ' is not a valid number');
-  }
-
-  return limit;
+  return limits[name];
 }
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
     "coveralls": "nyc report --reporter=lcov",
     "lint": "eslint .",
     "lint:everything": "npm run lint && npm run test:types",
+    "lint:fix": "standard --fix",
+    "lint:standard": "standard --verbose | snazzy",
     "test:mocha": "mocha test",
     "test:types": "tsd",
     "test:coverage": "nyc npm run test",
@@ -37,9 +39,12 @@
     "busboy": "^0.3.1",
     "chai": "^4.3.4",
     "eslint": "^8.3.0",
+    "eslint-config-standard": "^16.0.3",
     "eslint-plugin-node": "^11.1.0",
     "mocha": "^9.1.3",
     "nyc": "^15.1.0",
+    "snazzy": "^9.0.0",
+    "standard": "^16.0.4",
     "tsd": "^0.19.0",
     "typescript": "^4.5.2"
   },
@@ -61,6 +66,13 @@
       "module": "commonjs",
       "target": "ES2017"
     }
+  },
+  "standard": {
+    "globals": [ "describe", "it" ],
+    "ignore": [
+      "deps/encoding",
+      "bench"
+    ]
   },
   "files": [
     "README.md",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@types/node": "^16.11.10",
     "busboy": "^0.3.1",
     "chai": "^4.3.4",
-    "eslint": "^8.3.0",
+    "eslint": "^7.32.0",
     "eslint-config-standard": "^16.0.3",
     "eslint-plugin-node": "^11.1.0",
     "mocha": "^9.1.3",

--- a/test/dicer-multipart-extra-trailer.spec.js
+++ b/test/dicer-multipart-extra-trailer.spec.js
@@ -4,7 +4,7 @@ const assert = require('assert'),
   path = require('path'),
   inspect = require('util').inspect;
 
-const FIXTURES_ROOT = path.join(__dirname, '/fixtures/');
+const FIXTURES_ROOT = path.join(__dirname, 'fixtures/');
 
 describe('dicer-multipart-extra-trailer', () => {
   [

--- a/test/dicer-multipart-extra-trailer.spec.js
+++ b/test/dicer-multipart-extra-trailer.spec.js
@@ -1,9 +1,10 @@
 const Dicer = require('../deps/dicer/lib/Dicer');
 const assert = require('assert'),
   fs = require('fs'),
+  path = require('path'),
   inspect = require('util').inspect;
 
-const FIXTURES_ROOT = __dirname + '/fixtures/';
+const FIXTURES_ROOT = path.join(__dirname, '/fixtures/');
 
 describe('dicer-multipart-extra-trailer', () => {
   [
@@ -17,12 +18,11 @@ describe('dicer-multipart-extra-trailer', () => {
   ].forEach(function (v) {
     it(v.what, (done) => {
       let fixtureBase = FIXTURES_ROOT + v.source,
-        fd,
         n = 0,
         buffer = Buffer.allocUnsafe(v.chsize),
         state = { parts: [] };
 
-      fd = fs.openSync(fixtureBase + '/original', 'r');
+      const fd = fs.openSync(fixtureBase + '/original', 'r');
 
       const dicer = new Dicer(v.opts);
       let error,

--- a/test/dicer-multipart-nolisteners.spec.js
+++ b/test/dicer-multipart-nolisteners.spec.js
@@ -4,7 +4,7 @@ const assert = require('assert'),
   path = require('path'),
   inspect = require('util').inspect;
 
-const FIXTURES_ROOT = path.resolve(__dirname, 'fixtures/');
+const FIXTURES_ROOT = path.join(__dirname, '/fixtures/');
 
 describe('dicer-multipart-nolisteners', () => {
   [

--- a/test/dicer-multipart-nolisteners.spec.js
+++ b/test/dicer-multipart-nolisteners.spec.js
@@ -4,7 +4,7 @@ const assert = require('assert'),
   path = require('path'),
   inspect = require('util').inspect;
 
-const FIXTURES_ROOT = path.join(__dirname, '/fixtures/');
+const FIXTURES_ROOT = path.join(__dirname, 'fixtures/');
 
 describe('dicer-multipart-nolisteners', () => {
   [

--- a/test/dicer-multipart.spec.js
+++ b/test/dicer-multipart.spec.js
@@ -4,7 +4,7 @@ const assert = require('assert'),
   path = require('path'),
   inspect = require('util').inspect;
 
-const FIXTURES_ROOT = path.join(__dirname, '/fixtures/');
+const FIXTURES_ROOT = path.join(__dirname, 'fixtures/');
 
 describe('dicer-multipart', () => {
   [

--- a/test/dicer-multipart.spec.js
+++ b/test/dicer-multipart.spec.js
@@ -4,7 +4,7 @@ const assert = require('assert'),
   path = require('path'),
   inspect = require('util').inspect;
 
-const FIXTURES_ROOT = __dirname + '/fixtures/';
+const FIXTURES_ROOT = path.join(__dirname, '/fixtures/');
 
 describe('dicer-multipart', () => {
   [
@@ -58,9 +58,7 @@ describe('dicer-multipart', () => {
     it(v.what, (done) => {
 
       const fixtureBase = FIXTURES_ROOT + v.source;
-      let n = 0,
-        buffer = Buffer.allocUnsafe(v.chsize),
-        state = { parts: [], preamble: undefined };
+      const state = { parts: [], preamble: undefined };
 
       const dicer = new Dicer(v.opts);
       let error,


### PR DESCRIPTION
This PR is also for discussing  if we should switch to standardjs, like fastify core.

This PR adds all the changes, which need to be done manually to be conform with standardjs. It is easier to review the changes, which have to be done manually before doing a lint:fix, than doing a lint:fix and then fixing manually the stuff, which standardjs could not handle. 

I excluded deps/encoding as it is kind of a standalone part and messing with it is potentially critical. Also encoding-indexes.js is a huge file, so having it in a "compressed" format makes sense. 

So if we agree on using standardjs like fastify core does, we should merge this, and in a second PR we would just run `npm run lint:fix` and changing to standard for `npm run lint` in package.json.Also dont forget to add standard to extends attribute of eslint-configuration. 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
