### PR TITLE
add preserveEmptyFilename and preserveBlobFilename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,5 @@ Major changes since the last busboy release (0.31):
 * Error on non-number limit rather than ignoring (#7)
 * Dicer is now part of the busboy itself and not an external dependency (#14)
 * Tests were converted to Mocha (#11, #12, #22, #23)
+* If preserveEmptyFilename is set to false, empty filenames will be changed to `undefined` (#52)
+* If preserveBlobFilename is set to false, `blob` as filename will be changed to `undefined` (#52)

--- a/README.md
+++ b/README.md
@@ -221,9 +221,9 @@ Busboy methods
 
         * **preservePath** - _boolean_ - If paths in the multipart 'filename' field shall be preserved. (Default: false).
 
-        * **preserveEmptyFilename** - _boolean_ - Preserve the multipart 'filename' field as an empty string if it is an empty string. (Default: false).
+        * **preserveEmptyFilename** - _boolean_ - Preserve the multipart 'filename' field as an empty string if it is an empty string. (Default: true).
 
-        * **preserveBlobFilename** - _boolean_ - Preserve the multipart 'filename' field as 'blob' if it is set as 'blob'. (Default: false).
+        * **preserveBlobFilename** - _boolean_ - Preserve the multipart 'filename' field as 'blob' if it is set as 'blob'. (Default: true).
 
         * **limits** - _object_ - Various limits on incoming data. Valid properties are:
 

--- a/README.md
+++ b/README.md
@@ -221,6 +221,10 @@ Busboy methods
 
         * **preservePath** - _boolean_ - If paths in the multipart 'filename' field shall be preserved. (Default: false).
 
+        * **preserveEmptyFilename** - _boolean_ - Preserve the multipart 'filename' field as an empty string if it is an empty string. (Default: false).
+
+        * **preserveBlobFilename** - _boolean_ - Preserve the multipart 'filename' field as 'blob' if it is set as 'blob'. (Default: false).
+
         * **limits** - _object_ - Various limits on incoming data. Valid properties are:
 
             * **fieldNameSize** - _integer_ - Max field name size (in bytes) (Default: 100 bytes).

--- a/lib/main.d.ts
+++ b/lib/main.d.ts
@@ -39,12 +39,12 @@ export interface BusboyConfig {
      * If preserveEmptyFilename is set, an empty filename will be preserved.
      * @default true
      */
-     preserveEmptyFilename: boolean | undefined;
+     preserveEmptyFilename?: boolean | undefined;
     /**
      * If preserveBlobFilename is set, the filename 'blob' will be preserved.
      * @default true
      */
-     preserveBlobFilename: boolean | undefined;
+     preserveBlobFilename?: boolean | undefined;
     /**
      * Various limits on incoming data.
      */

--- a/lib/main.d.ts
+++ b/lib/main.d.ts
@@ -36,6 +36,16 @@ export interface BusboyConfig {
      */
     preservePath?: boolean | undefined;
     /**
+     * If preserveEmptyFilename is set, an empty filename will be preserved.
+     * @default true
+     */
+     preserveEmptyFilename: boolean | undefined;
+    /**
+     * If preserveBlobFilename is set, the filename 'blob' will be preserved.
+     * @default true
+     */
+     preserveBlobFilename: boolean | undefined;
+    /**
      * Various limits on incoming data.
      */
     limits?:

--- a/lib/main.js
+++ b/lib/main.js
@@ -47,7 +47,9 @@ Busboy.prototype.parseHeaders = function (headers) {
         highWaterMark: undefined,
         fileHwm: undefined,
         defCharset: undefined,
-        preservePath: false
+        preservePath: false,
+        preserveEmptyFilename: this.opts.preserveEmptyFilename !== false,
+        preserveBlobFilename: this.opts.preserveBlobFilename !== false
       }
       if (this.opts.highWaterMark) { cfg.highWaterMark = this.opts.highWaterMark }
       if (this.opts.fileHwm) { cfg.fileHwm = this.opts.fileHwm }

--- a/lib/types/multipart.js
+++ b/lib/types/multipart.js
@@ -29,6 +29,8 @@ function Multipart (boy, cfg) {
   const self = this
   let boundary
   const limits = cfg.limits
+  const preserveBlobFilename = cfg.preserveBlobFilename
+  const preserveEmptyFilename = cfg.preserveEmptyFilename
   const parsedConType = cfg.parsedConType || []
   const defCharset = cfg.defCharset || 'utf8'
   const preservePath = cfg.preservePath
@@ -143,6 +145,10 @@ function Multipart (boy, cfg) {
             filename = parsed[i][1]
             if (!preservePath) { filename = basename(filename) }
           }
+          if (
+            (!preserveEmptyFilename && filename === '') ||
+            (!preserveBlobFilename && filename === 'blob')
+          ) { filename = undefined }
         }
       } else { return skipPart(part) }
 

--- a/test/types-multipart.spec.js
+++ b/test/types-multipart.spec.js
@@ -179,7 +179,7 @@ describe('types-multipart', () => {
         ['file', 'upload_file_2', 26, 0, '1k_c.dat', '7bit', 'application/octet-stream']
       ],
       what: 'Files with filenames containing paths'
-    },    {
+    }, {
       source: [
         ['-----------------------------paZqsnEHRufoShdX6fh0lUhXBP4k',
           'Content-Disposition: form-data; name="upload_file_0"; filename=""',

--- a/test/types-multipart.spec.js
+++ b/test/types-multipart.spec.js
@@ -179,6 +179,113 @@ describe('types-multipart', () => {
         ['file', 'upload_file_2', 26, 0, '1k_c.dat', '7bit', 'application/octet-stream']
       ],
       what: 'Files with filenames containing paths'
+    },    {
+      source: [
+        ['-----------------------------paZqsnEHRufoShdX6fh0lUhXBP4k',
+          'Content-Disposition: form-data; name="upload_file_0"; filename=""',
+          'Content-Type: application/octet-stream',
+          '',
+          'ABCDEFGHIJKLMNOPQRSTUVWXYZ',
+          '-----------------------------paZqsnEHRufoShdX6fh0lUhXBP4k--'
+        ].join('\r\n')
+      ],
+      boundary: '---------------------------paZqsnEHRufoShdX6fh0lUhXBP4k',
+      expected: [
+        ['file', 'upload_file_0', 26, 0, '', '7bit', 'application/octet-stream']
+      ],
+      what: 'Files with empty filename keep the empty filename if preserveEmptyFilename is not set'
+    },
+    {
+      source: [
+        ['-----------------------------paZqsnEHRufoShdX6fh0lUhXBP4k',
+          'Content-Disposition: form-data; name="upload_file_0"; filename=""',
+          'Content-Type: application/octet-stream',
+          '',
+          'ABCDEFGHIJKLMNOPQRSTUVWXYZ',
+          '-----------------------------paZqsnEHRufoShdX6fh0lUhXBP4k--'
+        ].join('\r\n')
+      ],
+      boundary: '---------------------------paZqsnEHRufoShdX6fh0lUhXBP4k',
+      config: {
+        preserveEmptyFilename: false
+      },
+      expected: [
+        ['file', 'upload_file_0', 26, 0, undefined, '7bit', 'application/octet-stream']
+      ],
+      what: 'Files with empty filename have undefined set as filename if preserveEmptyFilename is set to false'
+    },
+    {
+      source: [
+        ['-----------------------------paZqsnEHRufoShdX6fh0lUhXBP4k',
+          'Content-Disposition: form-data; name="upload_file_0"; filename=""',
+          'Content-Type: application/octet-stream',
+          '',
+          'ABCDEFGHIJKLMNOPQRSTUVWXYZ',
+          '-----------------------------paZqsnEHRufoShdX6fh0lUhXBP4k--'
+        ].join('\r\n')
+      ],
+      boundary: '---------------------------paZqsnEHRufoShdX6fh0lUhXBP4k',
+      config: {
+        preserveEmptyFilename: true
+      },
+      expected: [
+        ['file', 'upload_file_0', 26, 0, '', '7bit', 'application/octet-stream']
+      ],
+      what: 'Files with empty filename keep the filename if preserveEmptyFilename is set to true'
+    },
+    {
+      source: [
+        ['-----------------------------paZqsnEHRufoShdX6fh0lUhXBP4k',
+          'Content-Disposition: form-data; name="upload_file_0"; filename="blob"',
+          'Content-Type: application/octet-stream',
+          '',
+          'ABCDEFGHIJKLMNOPQRSTUVWXYZ',
+          '-----------------------------paZqsnEHRufoShdX6fh0lUhXBP4k--'
+        ].join('\r\n')
+      ],
+      boundary: '---------------------------paZqsnEHRufoShdX6fh0lUhXBP4k',
+      expected: [
+        ['file', 'upload_file_0', 26, 0, 'blob', '7bit', 'application/octet-stream']
+      ],
+      what: 'Files with filename blob keep the filename as blob if preserveBlobFilename is not set'
+    },
+    {
+      source: [
+        ['-----------------------------paZqsnEHRufoShdX6fh0lUhXBP4k',
+          'Content-Disposition: form-data; name="upload_file_0"; filename="blob"',
+          'Content-Type: application/octet-stream',
+          '',
+          'ABCDEFGHIJKLMNOPQRSTUVWXYZ',
+          '-----------------------------paZqsnEHRufoShdX6fh0lUhXBP4k--'
+        ].join('\r\n')
+      ],
+      boundary: '---------------------------paZqsnEHRufoShdX6fh0lUhXBP4k',
+      config: {
+        preserveBlobFilename: false
+      },
+      expected: [
+        ['file', 'upload_file_0', 26, 0, undefined, '7bit', 'application/octet-stream']
+      ],
+      what: 'Files with filename blob have undefined set as filename if preserveBlobFilename is set to false'
+    },
+    {
+      source: [
+        ['-----------------------------paZqsnEHRufoShdX6fh0lUhXBP4k',
+          'Content-Disposition: form-data; name="upload_file_0"; filename="blob"',
+          'Content-Type: application/octet-stream',
+          '',
+          'ABCDEFGHIJKLMNOPQRSTUVWXYZ',
+          '-----------------------------paZqsnEHRufoShdX6fh0lUhXBP4k--'
+        ].join('\r\n')
+      ],
+      boundary: '---------------------------paZqsnEHRufoShdX6fh0lUhXBP4k',
+      config: {
+        preserveBlobFilename: true
+      },
+      expected: [
+        ['file', 'upload_file_0', 26, 0, 'blob', '7bit', 'application/octet-stream']
+      ],
+      what: 'Files with filename blob keep the filename as blob if preserveBlobFilename is set to true'
     },
     {
       source: [
@@ -289,6 +396,7 @@ describe('types-multipart', () => {
   tests.forEach((v) => {
     it(v.what, () => {
       const busboy = new Busboy({
+        ...v.config,
         limits: v.limits,
         preservePath: v.preservePath,
         headers: {


### PR DESCRIPTION
This PR is based on #26 

It introduces the configuration options `preserveEmptyFilename` and `preserveBlobFilename` to ensure, that this fork is non-breaking to original busboy.

Separate unit tests for each possibility, was added. 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
