### PR TITLE
handle blobs as fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,4 @@ Major changes since the last busboy release (0.31):
 * Error on non-number limit rather than ignoring (#7)
 * Dicer is now part of the busboy itself and not an external dependency (#14)
 * Tests were converted to Mocha (#11, #12, #22, #23)
+* Add isPartAFile-option, to make the file-detection configurable (#53)

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -1,3 +1,0 @@
-# Migrating from busboy
-
-While @fastify/busboy is intended to mostly be a drop-in replacement for bosboy, there are some changes you should be aware of when migrating:

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ Busboy methods
 
             * fieldName - __string__ The name of the field.
 
-            * contentType - __string__ The content-type of the Part, e.g. `text/plain`, `image/jpeg`, `application/octet-stream`
+            * contentType - __string__ The content-type of the part, e.g. `text/plain`, `image/jpeg`, `application/octet-stream`
 
             * fileName - __string__ The name of a file supplied by the part.
 

--- a/README.md
+++ b/README.md
@@ -221,6 +221,16 @@ Busboy methods
 
         * **preservePath** - _boolean_ - If paths in the multipart 'filename' field shall be preserved. (Default: false).
 
+        * **isPartAFile** - __function__ - Use this function to override the default file detection functionality. It has following parameters:
+
+            * fieldName - __string__ The name of the field.
+
+            * contentType - __string__ The content-type of the Part, e.g. `text/plain`, `image/jpeg`, `application/octet-stream`
+
+            * fileName - __string__ The name of a file supplied by the part.
+
+          (Default: `(fieldName, contentType, fileName) => (contentType === 'application/octet-stream' || fileName !== undefined)`)
+
         * **limits** - _object_ - Various limits on incoming data. Valid properties are:
 
             * **fieldNameSize** - _integer_ - Max field name size (in bytes) (Default: 100 bytes).

--- a/lib/main.d.ts
+++ b/lib/main.d.ts
@@ -39,7 +39,7 @@ export interface BusboyConfig {
      * 
      * Modify this to handle e.g. Blobs.
      */
-    isPartAFile?: ((fieldName?: string | undefined, contentType?: string | undefined, fileName?: string | undefined) => boolean) | undefined;
+    isPartAFile?: ((fieldName: string | undefined, contentType: string | undefined, fileName: string | undefined) => boolean) | undefined;
     /**
      * If paths in the multipart 'filename' field shall be preserved.
      * @default false

--- a/lib/main.d.ts
+++ b/lib/main.d.ts
@@ -31,6 +31,16 @@ export interface BusboyConfig {
      */
     defCharset?: string | undefined;
     /**
+     * Detect if a Part is a file.
+     * 
+     * By default a file is detected if contentType 
+     * is application/octet-stream or fileName is not
+     * undefined.
+     * 
+     * Modify this to handle e.g. Blobs.
+     */
+    isPartAFile?: ((fieldName?: string | undefined, contentType?: string | undefined, fileName?: string | undefined) => boolean) | undefined;
+    /**
      * If paths in the multipart 'filename' field shall be preserved.
      * @default false
      */

--- a/lib/main.d.ts
+++ b/lib/main.d.ts
@@ -39,7 +39,7 @@ export interface BusboyConfig {
      * 
      * Modify this to handle e.g. Blobs.
      */
-    isPartAFile?: ((fieldName: string | undefined, contentType: string | undefined, fileName: string | undefined) => boolean) | undefined;
+    isPartAFile?: (fieldName: string | undefined, contentType: string | undefined, fileName: string | undefined) => boolean;
     /**
      * If paths in the multipart 'filename' field shall be preserved.
      * @default false

--- a/lib/main.js
+++ b/lib/main.js
@@ -42,6 +42,7 @@ Busboy.prototype.parseHeaders = function (headers) {
     if (matched) {
       const cfg = {
         limits: this.opts.limits,
+        isPartAFile: this.opts.isPartAFile,
         headers: headers,
         parsedConType: parsed,
         highWaterMark: undefined,

--- a/lib/types/multipart.js
+++ b/lib/types/multipart.js
@@ -140,8 +140,7 @@ function Multipart (boy, cfg) {
         for (i = 0, len = parsed.length; i < len; ++i) {
           if (RE_NAME.test(parsed[i][0])) {
             fieldname = parsed[i][1]
-          }
-          if (RE_FILENAME.test(parsed[i][0])) {
+          } else if (RE_FILENAME.test(parsed[i][0])) {
             filename = parsed[i][1]
             if (!preservePath) { filename = basename(filename) }
           }

--- a/lib/types/multipart.js
+++ b/lib/types/multipart.js
@@ -22,14 +22,14 @@ const RE_FILENAME = /^filename$/i
 const RE_NAME = /^name$/i
 
 Multipart.detect = /^multipart\/form-data/i
-function Multipart(boy, cfg) {
+function Multipart (boy, cfg) {
   if (!(this instanceof Multipart)) { return new Multipart(boy, cfg) }
   let i
   let len
   const self = this
   let boundary
   const limits = cfg.limits
-  const isPartAFile = cfg.isPartAFile || ((fieldName, contentType, fileName) => (contentType === 'application/octet-stream' || fileName !== undefined));
+  const isPartAFile = cfg.isPartAFile || ((fieldName, contentType, fileName) => (contentType === 'application/octet-stream' || fileName !== undefined))
   const parsedConType = cfg.parsedConType || []
   const defCharset = cfg.defCharset || 'utf8'
   const preservePath = cfg.preservePath
@@ -45,7 +45,7 @@ function Multipart(boy, cfg) {
     }
   }
 
-  function checkFinished() {
+  function checkFinished () {
     if (nends === 0 && finished && !boy._done) {
       finished = false
       process.nextTick(function () {
@@ -91,7 +91,7 @@ function Multipart(boy, cfg) {
       self._cb = undefined
       cb()
     }
-  }).on('part', function onPart(part) {
+  }).on('part', function onPart (part) {
     if (++self._nparts > partsLimit) {
       self.parser.removeListener('part', onPart)
       self.parser.on('part', skipPart)
@@ -280,11 +280,11 @@ Multipart.prototype.end = function () {
   } else if (this.parser.writable) { this.parser.end() }
 }
 
-function skipPart(part) {
+function skipPart (part) {
   part.resume()
 }
 
-function FileStream(opts) {
+function FileStream (opts) {
   if (!(this instanceof FileStream)) { return new FileStream(opts) }
   ReadableStream.call(this, opts)
 

--- a/lib/types/multipart.js
+++ b/lib/types/multipart.js
@@ -150,7 +150,7 @@ function Multipart (boy, cfg) {
 
       let onData,
         onEnd
-      if (contype === 'application/octet-stream' || filename !== undefined) {
+      if (contype === 'application/octet-stream') {
         // file/binary field
         if (nfiles === filesLimit) {
           if (!boy.hitFilesLimit) {

--- a/lib/types/multipart.js
+++ b/lib/types/multipart.js
@@ -22,13 +22,14 @@ const RE_FILENAME = /^filename$/i
 const RE_NAME = /^name$/i
 
 Multipart.detect = /^multipart\/form-data/i
-function Multipart (boy, cfg) {
+function Multipart(boy, cfg) {
   if (!(this instanceof Multipart)) { return new Multipart(boy, cfg) }
   let i
   let len
   const self = this
   let boundary
   const limits = cfg.limits
+  const isPartAFile = cfg.isPartAFile || ((fieldName, contentType, fileName) => (contentType === 'application/octet-stream' || fileName !== undefined));
   const parsedConType = cfg.parsedConType || []
   const defCharset = cfg.defCharset || 'utf8'
   const preservePath = cfg.preservePath
@@ -38,13 +39,13 @@ function Multipart (boy, cfg) {
 
   for (i = 0, len = parsedConType.length; i < len; ++i) {
     if (Array.isArray(parsedConType[i]) &&
-        RE_BOUNDARY.test(parsedConType[i][0])) {
+      RE_BOUNDARY.test(parsedConType[i][0])) {
       boundary = parsedConType[i][1]
       break
     }
   }
 
-  function checkFinished () {
+  function checkFinished() {
     if (nends === 0 && finished && !boy._done) {
       finished = false
       process.nextTick(function () {
@@ -90,7 +91,7 @@ function Multipart (boy, cfg) {
       self._cb = undefined
       cb()
     }
-  }).on('part', function onPart (part) {
+  }).on('part', function onPart(part) {
     if (++self._nparts > partsLimit) {
       self.parser.removeListener('part', onPart)
       self.parser.on('part', skipPart)
@@ -139,7 +140,8 @@ function Multipart (boy, cfg) {
         for (i = 0, len = parsed.length; i < len; ++i) {
           if (RE_NAME.test(parsed[i][0])) {
             fieldname = parsed[i][1]
-          } else if (RE_FILENAME.test(parsed[i][0])) {
+          }
+          if (RE_FILENAME.test(parsed[i][0])) {
             filename = parsed[i][1]
             if (!preservePath) { filename = basename(filename) }
           }
@@ -150,7 +152,8 @@ function Multipart (boy, cfg) {
 
       let onData,
         onEnd
-      if (contype === 'application/octet-stream') {
+
+      if (isPartAFile(fieldname, contype, filename)) {
         // file/binary field
         if (nfiles === filesLimit) {
           if (!boy.hitFilesLimit) {
@@ -277,11 +280,11 @@ Multipart.prototype.end = function () {
   } else if (this.parser.writable) { this.parser.end() }
 }
 
-function skipPart (part) {
+function skipPart(part) {
   part.resume()
 }
 
-function FileStream (opts) {
+function FileStream(opts) {
   if (!(this instanceof FileStream)) { return new FileStream(opts) }
   ReadableStream.call(this, opts)
 
@@ -289,6 +292,6 @@ function FileStream (opts) {
 }
 inherits(FileStream, ReadableStream)
 
-FileStream.prototype._read = function (n) {}
+FileStream.prototype._read = function (n) { }
 
 module.exports = Multipart

--- a/test/types-multipart.spec.js
+++ b/test/types-multipart.spec.js
@@ -230,6 +230,9 @@ describe('types-multipart', () => {
       what: 'Empty content-type and empty content-disposition'
     },
     {
+      config: {
+        isPartAFile: (fieldName) => (fieldName !== 'upload_file_0'),
+      },
       source: [
         ['-----------------------------paZqsnEHRufoShdX6fh0lUhXBP4k',
           'Content-Disposition: form-data; name="upload_file_0"; filename="blob"',
@@ -305,6 +308,7 @@ describe('types-multipart', () => {
   tests.forEach((v) => {
     it(v.what, () => {
       const busboy = new Busboy({
+        ...v.config,
         limits: v.limits,
         preservePath: v.preservePath,
         headers: {

--- a/test/types-multipart.spec.js
+++ b/test/types-multipart.spec.js
@@ -231,7 +231,7 @@ describe('types-multipart', () => {
     },
     {
       config: {
-        isPartAFile: (fieldName) => (fieldName !== 'upload_file_0'),
+        isPartAFile: (fieldName) => (fieldName !== 'upload_file_0')
       },
       source: [
         ['-----------------------------paZqsnEHRufoShdX6fh0lUhXBP4k',

--- a/test/types-multipart.spec.js
+++ b/test/types-multipart.spec.js
@@ -232,6 +232,22 @@ describe('types-multipart', () => {
     {
       source: [
         ['-----------------------------paZqsnEHRufoShdX6fh0lUhXBP4k',
+          'Content-Disposition: form-data; name="upload_file_0"; filename="blob"',
+          'Content-Type: application/json',
+          '',
+          'ABCDEFGHIJKLMNOPQRSTUVWXYZ',
+          '-----------------------------paZqsnEHRufoShdX6fh0lUhXBP4k--'
+        ].join('\r\n')
+      ],
+      boundary: '---------------------------paZqsnEHRufoShdX6fh0lUhXBP4k',
+      expected: [
+        ['field', 'upload_file_0', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', false, false, '7bit', 'application/json']
+      ],
+      what: 'Blob uploads should be handled as fields.'
+    },
+    {
+      source: [
+        ['-----------------------------paZqsnEHRufoShdX6fh0lUhXBP4k',
           'Content-Disposition: form-data; name="file"; filename*=utf-8\'\'n%C3%A4me.txt',
           'Content-Type: application/octet-stream',
           '',

--- a/test/types-multipart.spec.js
+++ b/test/types-multipart.spec.js
@@ -271,7 +271,32 @@ describe('types-multipart', () => {
         ['field', 'upload_file_0', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', false, false, '7bit', 'application/json'],
         ['file', 'file', 26, 0, 'näme.txt', '7bit', 'application/octet-stream']
       ],
-      what: 'Blob uploads should be handled as fields if isPartAFile is provided. Other fields should be files.'
+      what: 'Blob uploads should be handled as fields if isPartAFile is provided. Other parts should be files.'
+    },
+    {
+      config: {
+        isPartAFile: (fieldName) => (fieldName === 'upload_file_0')
+      },
+      source: [
+        ['-----------------------------paZqsnEHRufoShdX6fh0lUhXBP4k',
+          'Content-Disposition: form-data; name="upload_file_0"; filename="blob"',
+          'Content-Type: application/json',
+          '',
+          'ABCDEFGHIJKLMNOPQRSTUVWXYZ',
+          '-----------------------------paZqsnEHRufoShdX6fh0lUhXBP4k',
+          'Content-Disposition: form-data; name="file"; filename*=utf-8\'\'n%C3%A4me.txt',
+          'Content-Type: application/octet-stream',
+          '',
+          'ABCDEFGHIJKLMNOPQRSTUVWXYZ',
+          '-----------------------------paZqsnEHRufoShdX6fh0lUhXBP4k--'
+        ].join('\r\n')
+      ],
+      boundary: '---------------------------paZqsnEHRufoShdX6fh0lUhXBP4k',
+      expected: [
+        ['file', 'upload_file_0', 26, 0, 'blob', '7bit', 'application/json'],
+        ['field', 'file', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', false, false, '7bit', 'application/octet-stream']
+      ],
+      what: 'Blob uploads should be handled as files if corresponding isPartAFile is provided. Other parts should be fields.'
     },
     {
       source: [

--- a/test/types-multipart.spec.js
+++ b/test/types-multipart.spec.js
@@ -246,7 +246,32 @@ describe('types-multipart', () => {
       expected: [
         ['field', 'upload_file_0', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', false, false, '7bit', 'application/json']
       ],
-      what: 'Blob uploads should be handled as fields.'
+      what: 'Blob uploads should be handled as fields if isPartAFile is provided.'
+    },
+    {
+      config: {
+        isPartAFile: (fieldName) => (fieldName !== 'upload_file_0')
+      },
+      source: [
+        ['-----------------------------paZqsnEHRufoShdX6fh0lUhXBP4k',
+          'Content-Disposition: form-data; name="upload_file_0"; filename="blob"',
+          'Content-Type: application/json',
+          '',
+          'ABCDEFGHIJKLMNOPQRSTUVWXYZ',
+          '-----------------------------paZqsnEHRufoShdX6fh0lUhXBP4k',
+          'Content-Disposition: form-data; name="file"; filename*=utf-8\'\'n%C3%A4me.txt',
+          'Content-Type: application/octet-stream',
+          '',
+          'ABCDEFGHIJKLMNOPQRSTUVWXYZ',
+          '-----------------------------paZqsnEHRufoShdX6fh0lUhXBP4k--'
+        ].join('\r\n')
+      ],
+      boundary: '---------------------------paZqsnEHRufoShdX6fh0lUhXBP4k',
+      expected: [
+        ['field', 'upload_file_0', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', false, false, '7bit', 'application/json'],
+        ['file', 'file', 26, 0, 'näme.txt', '7bit', 'application/octet-stream']
+      ],
+      what: 'Blob uploads should be handled as fields if isPartAFile is provided. Other fields should be files.'
     },
     {
       source: [

--- a/test/types/main.test-d.ts
+++ b/test/types/main.test-d.ts
@@ -23,6 +23,8 @@ new BusboyDefault({ headers: { 'content-type': 'foo' }, limits: { fileSize: 200 
 new BusboyDefault({ headers: { 'content-type': 'foo' }, limits: { files: 200 } }); // $ExpectType Busboy
 new BusboyDefault({ headers: { 'content-type': 'foo' }, limits: { parts: 200 } }); // $ExpectType Busboy
 new BusboyDefault({ headers: { 'content-type': 'foo' }, limits: { headerPairs: 200 } }); // $ExpectType Busboy
+new BusboyDefault({ headers: { 'content-type': 'foo' }, isPartAFile: (fieldName, contentType, fileName) => fieldName === 'my-special-field' || fileName !== 'not-so-special.txt' }); // $ExpectType Busboy
+new BusboyDefault({ headers: { 'content-type': 'foo' }, isPartAFile: (fieldName, contentType, fileName) => fileName !== undefined }); // $ExpectType Busboy
 
 busboy.addListener('file', (fieldname, file, filename, encoding, mimetype) => {
     expectType<string> (fieldname)


### PR DESCRIPTION
I think this handles the issue with blob uploads correctly:

It doesnt matter we have set a filename or not. We just check if the content is an octet stream. If so we treat it as a file. If not, we treat it as a field. 

Also according to the Spec, a filename is not mandatory.
https://datatracker.ietf.org/doc/html/rfc7578#section-4.2

```
   For form data that represents the content of a file, a name for the
   file SHOULD be supplied as well, by using a "filename" parameter of
   the Content-Disposition header field.  The file name isn't mandatory
   for cases where the file name isn't available or is meaningless or
   private; this might result, for example, when selection or drag-and-
   drop is used or when the form data content is streamed directly from
   a device.
```

So the check if filename was not undefined was already non spec conform. 

You could also create a Blob with mimetype `application/octet-stream` and upload it, and because we would maybe check for filename,e.g. 'blob' we would not handle the blob correctly. Blob only means, that we have the data in-memory of the browser. For the server it should be actually not be important if an upload was made with a blob or not. It should only look if it is octet-stream or not. 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
