### PR TITLE
fix empty part bug, 2nd try

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,4 @@ Major changes since the last busboy release (0.31):
 * Dicer is now part of the busboy itself and not an external dependency (#14)
 * Tests were converted to Mocha (#11, #12, #22, #23)
 * Add isPartAFile-option, to make the file-detection configurable (#53)
+* Empty Parts will not hang the process (#55)

--- a/deps/dicer/lib/Dicer.js
+++ b/deps/dicer/lib/Dicer.js
@@ -171,7 +171,7 @@ Dicer.prototype._oninfo = function (isMatch, data, start, end) {
   if (isMatch) {
     this._hparser.reset()
     if (this._isPreamble) { this._isPreamble = false } else {
-      if (end > start) {
+      if (start !== end) {
         ++this._parts
         this._part.on('end', function () {
           if (--self._parts === 0) {

--- a/deps/dicer/lib/Dicer.js
+++ b/deps/dicer/lib/Dicer.js
@@ -172,18 +172,18 @@ Dicer.prototype._oninfo = function (isMatch, data, start, end) {
     this._hparser.reset()
     if (this._isPreamble) { this._isPreamble = false } else {
       // if (end > start) {
-        ++this._parts
-        this._part.on('end', function () {
-          if (--self._parts === 0) {
-            if (self._finished) {
-              self._realFinish = true
-              self.emit('finish')
-              self._realFinish = false
-            } else {
-              self._unpause()
-            }
+      ++this._parts
+      this._part.on('end', function () {
+        if (--self._parts === 0) {
+          if (self._finished) {
+            self._realFinish = true
+            self.emit('finish')
+            self._realFinish = false
+          } else {
+            self._unpause()
           }
-        })
+        }
+      })
       // }
     }
     this._part.push(null)

--- a/deps/dicer/lib/Dicer.js
+++ b/deps/dicer/lib/Dicer.js
@@ -171,20 +171,20 @@ Dicer.prototype._oninfo = function (isMatch, data, start, end) {
   if (isMatch) {
     this._hparser.reset()
     if (this._isPreamble) { this._isPreamble = false } else {
-      // if (end > start) {
-      ++this._parts
-      this._part.on('end', function () {
-        if (--self._parts === 0) {
-          if (self._finished) {
-            self._realFinish = true
-            self.emit('finish')
-            self._realFinish = false
-          } else {
-            self._unpause()
+      if (end > start) {
+        ++this._parts
+        this._part.on('end', function () {
+          if (--self._parts === 0) {
+            if (self._finished) {
+              self._realFinish = true
+              self.emit('finish')
+              self._realFinish = false
+            } else {
+              self._unpause()
+            }
           }
-        }
-      })
-      // }
+        })
+      }
     }
     this._part.push(null)
     this._part = undefined

--- a/deps/dicer/lib/Dicer.js
+++ b/deps/dicer/lib/Dicer.js
@@ -171,18 +171,20 @@ Dicer.prototype._oninfo = function (isMatch, data, start, end) {
   if (isMatch) {
     this._hparser.reset()
     if (this._isPreamble) { this._isPreamble = false } else {
-      ++this._parts
-      this._part.on('end', function () {
-        if (--self._parts === 0) {
-          if (self._finished) {
-            self._realFinish = true
-            self.emit('finish')
-            self._realFinish = false
-          } else {
-            self._unpause()
+      // if (end > start) {
+        ++this._parts
+        this._part.on('end', function () {
+          if (--self._parts === 0) {
+            if (self._finished) {
+              self._realFinish = true
+              self.emit('finish')
+              self._realFinish = false
+            } else {
+              self._unpause()
+            }
           }
-        }
-      })
+        })
+      // }
     }
     this._part.push(null)
     this._part = undefined

--- a/test/dicer-endfinish.spec.js
+++ b/test/dicer-endfinish.spec.js
@@ -2,7 +2,7 @@ const Dicer = require('../deps/dicer/lib/Dicer')
 const { assert } = require('chai')
 
 describe('dicer-endfinish', () => {
-  it('should properly handle finish', () => {
+  it('should properly handle finish', (done) => {
     const CRLF = '\r\n'
     const boundary = 'boundary'
 
@@ -79,6 +79,7 @@ describe('dicer-endfinish', () => {
     function pauseAfterEnd () {
       assert(firedPauseCallback, 'Failed to call callback after pause')
       assert(firedPauseFinish, 'Failed to finish after pause')
+      done()
     }
     function pauseFinish () {
       firedPauseFinish = true

--- a/test/dicer-headerparser.spec.js
+++ b/test/dicer-headerparser.spec.js
@@ -49,7 +49,7 @@ describe('dicer-headerparser', () => {
       what: 'Max header size (multiple chunk #2)'
     }
   ].forEach(function (v) {
-    it(v.what, () => {
+    it(v.what, (done) => {
       const parser = new HeaderParser()
       let fired = false
 
@@ -65,6 +65,7 @@ describe('dicer-headerparser', () => {
         parser.push(s)
       })
       assert(fired, `${v.what}: Did not receive header from parser`)
+      done()
     })
   })
 })

--- a/test/multipart-stream-pause.spec.js
+++ b/test/multipart-stream-pause.spec.js
@@ -20,7 +20,7 @@ function formDataFile (key, filename, contentType) {
 }
 
 describe('multipart-stream-pause', () => {
-  it('processes stream correctly', () => {
+  it('processes stream correctly', (done) => {
     const reqChunks = [
       Buffer.concat([
         formDataFile('file', 'file.bin', 'application/octet-stream'),
@@ -67,8 +67,10 @@ describe('multipart-stream-pause', () => {
           'Result mismatch:\nParsed: ' + inspect(result) +
             '\nExpected: ' + inspect(expected[i]))
       })
+      done()
     }).on('error', function (err) {
       assert(false, 'Unexpected error: ' + err.stack)
+      done(err)
     })
 
     reqChunks.forEach(function (buf) {

--- a/test/types-multipart.spec.js
+++ b/test/types-multipart.spec.js
@@ -381,7 +381,39 @@ describe('types-multipart', () => {
         ['field', 'activationauth', '', false, false, '7bit', 'text/plain'],
         ['field', 'seccodemodid', 'member::register', false, false, '7bit', 'text/plain']
       ],
-      what: 'empty part'
+      what: 'one empty part should get ignored'
+    },
+    {
+      source: [[
+        '------WebKitFormBoundaryzca7IDMnT6QwqBp7',
+        'Content-Disposition: form-data; name="regsubmit"',
+        '',
+        'yes',
+        '------WebKitFormBoundaryzca7IDMnT6QwqBp7',
+        '------WebKitFormBoundaryzca7IDMnT6QwqBp7',
+        '------WebKitFormBoundaryzca7IDMnT6QwqBp7',
+        '------WebKitFormBoundaryzca7IDMnT6QwqBp7',
+        'Content-Disposition: form-data; name="referer"',
+        '',
+        'http://domainExample/./',
+        '------WebKitFormBoundaryzca7IDMnT6QwqBp7',
+        'Content-Disposition: form-data; name="activationauth"',
+        '',
+        '',
+        '------WebKitFormBoundaryzca7IDMnT6QwqBp7',
+        'Content-Disposition: form-data; name="seccodemodid"',
+        '',
+        'member::register',
+        '------WebKitFormBoundaryzca7IDMnT6QwqBp7--'].join('\r\n')
+      ],
+      boundary: '----WebKitFormBoundaryzca7IDMnT6QwqBp7',
+      expected: [
+        ['field', 'regsubmit', 'yes', false, false, '7bit', 'text/plain'],
+        ['field', 'referer', 'http://domainExample/./', false, false, '7bit', 'text/plain'],
+        ['field', 'activationauth', '', false, false, '7bit', 'text/plain'],
+        ['field', 'seccodemodid', 'member::register', false, false, '7bit', 'text/plain']
+      ],
+      what: 'multiple empty parts should get ignored'
     }
   ]
 

--- a/test/types-multipart.spec.js
+++ b/test/types-multipart.spec.js
@@ -382,7 +382,7 @@ describe('types-multipart', () => {
         ['field', 'seccodemodid', 'member::register', false, false, '7bit', 'text/plain']
       ],
       what: 'empty part'
-    },
+    }
   ]
 
   tests.forEach((v) => {

--- a/test/types-multipart.spec.js
+++ b/test/types-multipart.spec.js
@@ -352,7 +352,37 @@ describe('types-multipart', () => {
       boundary: '----WebKitFormBoundaryTB2MiQ36fnSJlrhY',
       expected: [],
       what: 'empty form'
-    }
+    },
+    {
+      source: [[
+        '------WebKitFormBoundaryzca7IDMnT6QwqBp7',
+        'Content-Disposition: form-data; name="regsubmit"',
+        '',
+        'yes',
+        '------WebKitFormBoundaryzca7IDMnT6QwqBp7',
+        '------WebKitFormBoundaryzca7IDMnT6QwqBp7',
+        'Content-Disposition: form-data; name="referer"',
+        '',
+        'http://domainExample/./',
+        '------WebKitFormBoundaryzca7IDMnT6QwqBp7',
+        'Content-Disposition: form-data; name="activationauth"',
+        '',
+        '',
+        '------WebKitFormBoundaryzca7IDMnT6QwqBp7',
+        'Content-Disposition: form-data; name="seccodemodid"',
+        '',
+        'member::register',
+        '------WebKitFormBoundaryzca7IDMnT6QwqBp7--'].join('\r\n')
+      ],
+      boundary: '----WebKitFormBoundaryzca7IDMnT6QwqBp7',
+      expected: [
+        // ['field', 'regsubmit', 'yes', false, false, '7bit', 'text/plain'],
+        ['field', 'referer', 'http://domainExample/./', false, false, '7bit', 'text/plain'],
+        ['field', 'activationauth', '', false, false, '7bit', 'text/plain'],
+        ['field', 'seccodemodid', 'member::register', false, false, '7bit', 'text/plain']
+      ],
+      what: 'empty part'
+    },
   ]
 
   tests.forEach((v) => {

--- a/test/types-multipart.spec.js
+++ b/test/types-multipart.spec.js
@@ -376,7 +376,7 @@ describe('types-multipart', () => {
       ],
       boundary: '----WebKitFormBoundaryzca7IDMnT6QwqBp7',
       expected: [
-        // ['field', 'regsubmit', 'yes', false, false, '7bit', 'text/plain'],
+        ['field', 'regsubmit', 'yes', false, false, '7bit', 'text/plain'],
         ['field', 'referer', 'http://domainExample/./', false, false, '7bit', 'text/plain'],
         ['field', 'activationauth', '', false, false, '7bit', 'text/plain'],
         ['field', 'seccodemodid', 'member::register', false, false, '7bit', 'text/plain']
@@ -386,7 +386,7 @@ describe('types-multipart', () => {
   ]
 
   tests.forEach((v) => {
-    it(v.what, () => {
+    it(v.what, (done) => {
       const busboy = new Busboy({
         ...v.config,
         limits: v.limits,
@@ -439,8 +439,9 @@ describe('types-multipart', () => {
                         '\nExpected: ' + inspect(v.expected[i])
           )
         })
+        done()
       }).on('error', function (err) {
-        if (!v.shouldError || v.shouldError !== err.message) { assert(false, 'Unexpected error: ' + err) }
+        if (!v.shouldError || v.shouldError !== err.message) { assert(false, 'Unexpected error: ' + err); done(err)}
       })
 
       v.source.forEach(function (s) {

--- a/test/types-multipart.spec.js
+++ b/test/types-multipart.spec.js
@@ -441,7 +441,7 @@ describe('types-multipart', () => {
         })
         done()
       }).on('error', function (err) {
-        if (!v.shouldError || v.shouldError !== err.message) { assert(false, 'Unexpected error: ' + err); done(err)}
+        if (!v.shouldError || v.shouldError !== err.message) { assert(false, 'Unexpected error: ' + err); done(err) }
       })
 
       v.source.forEach(function (s) {

--- a/test/types-urlencoded.spec.js
+++ b/test/types-urlencoded.spec.js
@@ -145,7 +145,7 @@ const tests = [
 
 describe('types urlencoded', () => {
   tests.forEach((v) => {
-    it(v.what, () => {
+    it(v.what, (done) => {
       const busboy = new Busboy({
         limits: v.limits,
         headers: {
@@ -178,6 +178,7 @@ describe('types urlencoded', () => {
           )
           ++i
         })
+        done()
       })
 
       v.source.forEach(function (s) {


### PR DESCRIPTION
@ruur
@kibertoad 

Lets talk about the empty part bug here.

I use a simpler test than in the original PR. As you can see, it doesnt throw an error, despite it should throw an "Uncaught AssertionError: Parsed result count mismatch. Saw 4. Expected: 3: expected 4 to deeply equal 3"

If you uncomment the part in Dicer.js, you will see that it will then throw the expected AssertionError. Then you uncomment that line in the unit test, and it will become green.

I could not create a red phase, because it is like @ruur described hanging. So if you confirm @kibertoad  I would uncomment the commented out codes, and we should merge it.


<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
