### PR TITLE
introduce headerSize limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,4 +12,4 @@ Major changes since the last busboy release (0.3.1):
 * Add isPartAFile-option, to make the file-detection configurable (#53)
 * Empty Parts will not hang the process (#55)
 * FileStreams also provide the property `bytesRead` (#51)
-* add and expose headerSize limit
+* add and expose headerSize limit (#64)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-Major changes since the last busboy release (0.31):
+Major changes since the last busboy release (0.3.1):
 
 # 1.0.0 - TBD, 2021
 
@@ -11,4 +11,5 @@ Major changes since the last busboy release (0.31):
 * Tests were converted to Mocha (#11, #12, #22, #23)
 * Add isPartAFile-option, to make the file-detection configurable (#53)
 * Empty Parts will not hang the process (#55)
-* FileStreams also provide the property `bytesRead`
+* FileStreams also provide the property `bytesRead` (#51)
+* add and expose headerSize limit

--- a/README.md
+++ b/README.md
@@ -253,7 +253,9 @@ Busboy methods
 
             * **parts** - _integer_ - For multipart forms, the max number of parts (fields + files) (Default: Infinity).
 
-            * **headerPairs** - _integer_ - For multipart forms, the max number of header key=>value pairs to parse **Default:** 2000 (same as node's http).
+            * **headerPairs** - _integer_ - For multipart forms, the max number of header key=>value pairs to parse **Default:** 2000
+
+            * **headerSize** - _integer_ - For multipart forms, the max size of a multipart header **Default:** 81920.
 
     * The constructor can throw errors:
 

--- a/lib/main.d.ts
+++ b/lib/main.d.ts
@@ -82,9 +82,15 @@ export interface BusboyConfig {
         parts?: number | undefined;
         /**
          * For multipart forms, the max number of header key=>value pairs to parse
-         * @default 2000 (same as node's http)
+         * @default 2000
          */
         headerPairs?: number | undefined;
+
+        /**
+         * For multipart forms, the max size of a header part
+         * @default 81920
+         */
+        headerSize?: number | undefined;
     }
     | undefined;
 }

--- a/lib/types/multipart.js
+++ b/lib/types/multipart.js
@@ -61,6 +61,7 @@ function Multipart (boy, cfg) {
   const fieldsLimit = getLimit(limits, 'fields', Infinity)
   const partsLimit = getLimit(limits, 'parts', Infinity)
   const headerPairsLimit = getLimit(limits, 'headerPairs', 2000)
+  const headerSizeLimit = getLimit(limits, 'headerSize', 80 * 1024)
 
   let nfiles = 0
   let nfields = 0
@@ -78,6 +79,7 @@ function Multipart (boy, cfg) {
   const parserCfg = {
     boundary: boundary,
     maxHeaderPairs: headerPairsLimit,
+    maxHeaderSize: headerSizeLimit,
     partHwm: fileOpts.highWaterMark,
     highWaterMark: cfg.highWaterMark
   }

--- a/test/dicer-headerparser.spec.js
+++ b/test/dicer-headerparser.spec.js
@@ -107,6 +107,14 @@ describe('dicer-headerparser', () => {
       what: 'Folded values'
     },
     {
+      source: [
+        'Foo: bar',
+        'Foo: baz',
+      ].join('\r\n') + DCRLF,
+      expected: { foo: ['bar', 'baz'] },
+      what: 'Folded values'
+    },
+    {
       source: ['Content-Type:',
         'Foo: '
       ].join('\r\n') + DCRLF,

--- a/test/dicer-headerparser.spec.js
+++ b/test/dicer-headerparser.spec.js
@@ -133,7 +133,8 @@ describe('dicer-headerparser', () => {
       const cfg = {
         ...v.cfg
       }
-      const parser = new HeaderParser(cfg)
+
+      const parser = Object.keys(cfg).length ? new HeaderParser(cfg) : new HeaderParser
       let fired = false
 
       parser.on('header', function (header) {

--- a/test/dicer-headerparser.spec.js
+++ b/test/dicer-headerparser.spec.js
@@ -109,7 +109,7 @@ describe('dicer-headerparser', () => {
     {
       source: [
         'Foo: bar',
-        'Foo: baz',
+        'Foo: baz'
       ].join('\r\n') + DCRLF,
       expected: { foo: ['bar', 'baz'] },
       what: 'Folded values'

--- a/test/dicer-headerparser.spec.js
+++ b/test/dicer-headerparser.spec.js
@@ -134,7 +134,7 @@ describe('dicer-headerparser', () => {
         ...v.cfg
       }
 
-      const parser = Object.keys(cfg).length ? new HeaderParser(cfg) : new HeaderParser
+      const parser = Object.keys(cfg).length ? new HeaderParser(cfg) : new HeaderParser()
       let fired = false
 
       parser.on('header', function (header) {

--- a/test/types/main.test-d.ts
+++ b/test/types/main.test-d.ts
@@ -22,6 +22,7 @@ new BusboyDefault({ headers: { 'content-type': 'foo' }, limits: { fileSize: 200 
 new BusboyDefault({ headers: { 'content-type': 'foo' }, limits: { files: 200 } }); // $ExpectType Busboy
 new BusboyDefault({ headers: { 'content-type': 'foo' }, limits: { parts: 200 } }); // $ExpectType Busboy
 new BusboyDefault({ headers: { 'content-type': 'foo' }, limits: { headerPairs: 200 } }); // $ExpectType Busboy
+new BusboyDefault({ headers: { 'content-type': 'foo' }, limits: { headerSize: 200 } }); // $ExpectType Busboy
 new BusboyDefault({ headers: { 'content-type': 'foo' }, isPartAFile: (fieldName, contentType, fileName) => fieldName === 'my-special-field' || fileName !== 'not-so-special.txt' }); // $ExpectType Busboy
 new BusboyDefault({ headers: { 'content-type': 'foo' }, isPartAFile: (fieldName, contentType, fileName) => fileName !== undefined }); // $ExpectType Busboy
 


### PR DESCRIPTION
According to the comments, the maxHeaderSize should be actually be corresponding to the node http modules maxHeaderSize value. But it is actually wrong, as the default maxHeaderSize is and was always 8 kb and not 80 kb. On the other hand, the header of a request is different than the header of a multipart. 

With this PR we expose headerSize as configurable limit.  So if somebody wants to reduce the allowed size of a header, it is now possible to set the limit. 

This PR is non-breaking, as the original 80 kbytes are still enforced. Maybe we should inform in a security part of the readme.md that we recommend to reduce the header size to something smaller. 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
