### PR TITLE
feat: improve array parse performances

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -34,12 +34,13 @@ function parseParams (str) {
   let tmp = ''
 
   for (var i = 0, len = str.length; i < len; ++i) { // eslint-disable-line no-var
-    if (str[i] === '\\' && inquote) {
+    const char = str[i]
+    if (char === '\\' && inquote) {
       if (escaping) { escaping = false } else {
         escaping = true
         continue
       }
-    } else if (str[i] === '"') {
+    } else if (char === '"') {
       if (!escaping) {
         if (inquote) {
           inquote = false
@@ -50,7 +51,7 @@ function parseParams (str) {
     } else {
       if (escaping && inquote) { tmp += '\\' }
       escaping = false
-      if ((state === 'charset' || state === 'lang') && str[i] === "'") {
+      if ((state === 'charset' || state === 'lang') && char === "'") {
         if (state === 'charset') {
           state = 'lang'
           charset = tmp.substring(1)
@@ -58,13 +59,13 @@ function parseParams (str) {
         tmp = ''
         continue
       } else if (state === 'key' &&
-        (str[i] === '*' || str[i] === '=') &&
+        (char === '*' || char === '=') &&
         res.length) {
-        if (str[i] === '*') { state = 'charset' } else { state = 'value' }
+        if (char === '*') { state = 'charset' } else { state = 'value' }
         res[p] = [tmp, undefined]
         tmp = ''
         continue
-      } else if (!inquote && str[i] === ';') {
+      } else if (!inquote && char === ';') {
         state = 'key'
         if (charset) {
           if (tmp.length) {
@@ -80,9 +81,9 @@ function parseParams (str) {
         tmp = ''
         ++p
         continue
-      } else if (!inquote && (str[i] === ' ' || str[i] === '\t')) { continue }
+      } else if (!inquote && (char === ' ' || char === '\t')) { continue }
     }
-    tmp += str[i]
+    tmp += char
   }
   if (charset && tmp.length) {
     tmp = decodeText(tmp.replace(RE_ENCODED, encodedReplacer),


### PR DESCRIPTION
As there is a lot of test for `str[i]` value in this loop, keeping the value in a separated variable is faster.

Sidenote: `bench:busboy` script is not working.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
