### PR TITLE
Fix potential ReDOS-Attack-Vector in Headerparser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-Major changes since the last busboy release (0.31):
+Major changes since the last busboy release (0.3.1):
+
+# 1.0.1 - TBD
+
+* Fix potential ReDOS-Attack-Vector in Headerparser (#72)
 
 # 1.0.0 - 04 December, 2021
 

--- a/deps/dicer/lib/HeaderParser.js
+++ b/deps/dicer/lib/HeaderParser.js
@@ -79,14 +79,19 @@ HeaderParser.prototype._parseHeader = function () {
         continue
       }
     }
+
+    const posColon = lines[i].indexOf(':')
+    if (
+      posColon === -1 ||
+      posColon === 0
+    ) {
+      return
+    }
     m = RE_HDR.exec(lines[i])
-    if (m) {
-      h = m[1].toLowerCase()
-      if (m[2]) {
-        if (this.header[h] === undefined) { this.header[h] = [m[2]] } else { this.header[h].push(m[2]) }
-      } else { this.header[h] = [''] }
-      if (++this.npairs === this.maxHeaderPairs) { break }
-    } else { return }
+    h = m[1].toLowerCase()
+    this.header[h] = this.header[h] || []
+    this.header[h].push((m[2] || ''))
+    if (++this.npairs === this.maxHeaderPairs) { break }
   }
 }
 

--- a/test/dicer-headerparser.spec.js
+++ b/test/dicer-headerparser.spec.js
@@ -90,6 +90,27 @@ describe('dicer-headerparser', () => {
       what: 'should enforce maxHeaderSize of 32 and get only first character of second pair'
     },
     {
+      source: ['Content-Type:\r\n text/plain',
+        ' : '
+      ].join('\r\n') + DCRLF,
+      expected: { 'content-type': [' text/plain : '] },
+      what: 'should not break if invalid header pair (colon exists but empty key and value) is provided'
+    },
+    {
+      source: ['Content-Type:\r\n text/plain',
+        'FoobazFoobazFoobazFoobazFoobazFoobazFoobazFoobazFoobazFoobazFoobazFoobazFoobazFoobazFoobazFoobazFoobazFoobazFoobazFoobaz'
+      ].join('\r\n') + DCRLF,
+      expected: { 'content-type': [' text/plain'] },
+      what: 'should not break if invalid header pair (no distinctive colon) is provided'
+    },
+    {
+      source: ['Content-Type:\r\n text/plain',
+        ':FoobazFoobazFoobazFoobazFoobazFoobazFoobazFoobazFoobazFoobazFoobazFoobazFoobazFoobazFoobazFoobazFoobazFoobazFoobazFoobaz'
+      ].join('\r\n') + DCRLF,
+      expected: { 'content-type': [' text/plain'] },
+      what: 'should not break if invalid header pair (no key) is provided'
+    },
+    {
       source: ['Content-Type:\t  text/plain',
         'Content-Length:0'
       ].join('\r\n') + DCRLF,


### PR DESCRIPTION
tl;dr;
An attacker could send a payload with large headers, which contain no colon, repeatedly, resulting in a REDoS-Attack. 

The Regex for handling headerpairs is prone to catastrophic backtracking. 

This is even more critical, as busboys default limit for multipart headers is 80kby and that if a header is not valid, the counter for headers is not increasing. Meaning, that the attacker could send a big payload of multipart formdata, were each multipart contains 80kby of invalid headerdata resulting in a DoS-Attack.

To avoid this, we just check if the line contains a colon and if so ensure that it is not at the first position. If not we exit early. If not we can savely use the Regex for the header as before.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
