### PR TITLE
Make benchmark results monospaced

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ Benchmark (Mean time for 500 Kb payload, 2000 cycles, 1000 cycle warmup):
 
 | Library               | Mean time in nanoseconds (less is better) |
 |-----------------------|-------------------------------------------|
-| busboy 0.31           | 340114                                    |
-| @fastify/busboy 1.0.0 | 270984                                    |
+| busboy 0.31           | `340114`                                  |
+| @fastify/busboy 1.0.0 | `270984`                                  |
 
 [Changelog](https://github.com/fastify/busboy/blob/master/CHANGELOG.md) since busboy 0.31.
 


### PR DESCRIPTION
Make benchmark results monospaced so they align vertically and are easier to compare.

