### PR TITLE
ci!: migrate to reusable workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,36 +11,5 @@ on:
       - '*.md'
 
 jobs:
-  build:
-    runs-on: ${{ matrix.os }}
-
-    strategy:
-      matrix:
-        node-version: [10, 12, 14, 16, 17]
-        os: [macos-latest, ubuntu-latest]
-
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Use Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: ${{ matrix.node-version }}
-
-      - name: Install
-        run: |
-          npm install
-      - name: Run Tests
-        run: |
-          npm run test
-
-  automerge:
-    needs: build
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
-      contents: write
-    steps:
-      - uses: fastify/github-action-merge-dependabot@v3
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+  test:
+    uses: fastify/workflows/.github/workflows/plugins-ci.yml@v3

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 [![Build Status](https://github.com/fastify/busboy/workflows/ci/badge.svg)](https://github.com/fastify/busboy/actions)
 [![Coverage Status](https://coveralls.io/repos/fastify/busboy/badge.svg?branch=master)](https://coveralls.io/r/fastify/busboy?branch=master)
 [![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat)](https://standardjs.com/)
-[![Known Vulnerabilities](https://snyk.io/test/github/fastify/busboy/badge.svg)](https://snyk.io/test/github/fastify/busboy)
 [![Security Responsible Disclosure](https://img.shields.io/badge/Security-Responsible%20Disclosure-yellow.svg)](https://github.com/nodejs/security-wg/blob/HEAD/processes/responsible_disclosure_template.md)
 
 </div>

--- a/lib/main.js
+++ b/lib/main.js
@@ -54,7 +54,7 @@ Busboy.prototype.getParserByHeaders = function (headers) {
   const cfg = {
     defCharset: this.opts.defCharset,
     fileHwm: this.opts.fileHwm,
-    headers: headers,
+    headers,
     highWaterMark: this.opts.highWaterMark,
     isPartAFile: this.opts.isPartAFile,
     limits: this.opts.limits,

--- a/lib/types/multipart.js
+++ b/lib/types/multipart.js
@@ -76,7 +76,7 @@ function Multipart (boy, cfg) {
   this._boy = boy
 
   const parserCfg = {
-    boundary: boundary,
+    boundary,
     maxHeaderPairs: headerPairsLimit,
     maxHeaderSize: headerSizeLimit,
     partHwm: fileOpts.highWaterMark,

--- a/test/dicer-endfinish.spec.js
+++ b/test/dicer-endfinish.spec.js
@@ -21,7 +21,7 @@ describe('dicer-endfinish', () => {
     let firedEnd = false
     let firedFinish = false
 
-    const dicer = new Dicer({ boundary: boundary })
+    const dicer = new Dicer({ boundary })
     dicer.on('part', partListener)
     dicer.on('finish', finishListener)
     dicer.write(writePart + writeSep)
@@ -55,7 +55,7 @@ describe('dicer-endfinish', () => {
     let dicer2 = null
 
     function test2 () {
-      dicer2 = new Dicer({ boundary: boundary })
+      dicer2 = new Dicer({ boundary })
       dicer2.on('part', pausePartListener)
       dicer2.on('finish', pauseFinish)
       dicer2.write(writePart + writeSep, 'utf8', pausePartCallback)


### PR DESCRIPTION
BREAKING CHANGE: drops support for node 10, 12, and 17; adds support for node 18

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
