### PR TITLE
build(deps-dev): replace eslint-plugin-node with eslint-plugin-n

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,11 +9,11 @@ module.exports = {
   extends: [
     'standard',
     'eslint:recommended',
-    'plugin:node/recommended'
+    'plugin:n/recommended'
   ],
   rules: {
     'no-unused-vars': [1, { vars: 'all', args: 'none' }],
-    'node/no-missing-require': 1,
+    'n/no-missing-require': 1,
     'no-constant-condition': 'off',
     'no-var': 'off',
     'no-redeclare': 1,

--- a/package.json
+++ b/package.json
@@ -40,9 +40,9 @@
   "devDependencies": {
     "@types/node": "^18.0.0",
     "busboy": "^1.0.0",
-    "chai": "^4.3.4",
-    "eslint": "^7.32.0",
-    "eslint-config-standard": "^16.0.3",
+    "chai": "^4.3.6",
+    "eslint": "^8.23.0",
+    "eslint-config-standard": "^17.0.0",
     "eslint-plugin-n": "^15.2.5",
     "mocha": "^10.0.0",
     "nyc": "^15.1.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "chai": "^4.3.4",
     "eslint": "^7.32.0",
     "eslint-config-standard": "^16.0.3",
-    "eslint-plugin-node": "^11.1.0",
+    "eslint-plugin-n": "^15.2.5",
     "mocha": "^10.0.0",
     "nyc": "^15.1.0",
     "photofinish": "^1.8.0",


### PR DESCRIPTION
`eslint-plugin-node` is no longer maintained.
Main repo migrated a while back:

https://github.com/fastify/fastify/blob/67bee117a7c5c6dad503f656204e49cf329a37af/package.json#L144

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
