### PR TITLE
fix: Remove dicer dependency to `libs/utils.js`

### DIFF
--- a/deps/dicer/lib/HeaderParser.js
+++ b/deps/dicer/lib/HeaderParser.js
@@ -1,6 +1,5 @@
 const EventEmitter = require('events').EventEmitter
 const inherits = require('util').inherits
-const getLimit = require('../../../lib/utils').getLimit
 
 const StreamSearch = require('../../streamsearch/sbmh')
 
@@ -93,6 +92,21 @@ HeaderParser.prototype._parseHeader = function () {
     this.header[h].push((m[2] || ''))
     if (++this.npairs === this.maxHeaderPairs) { break }
   }
+}
+
+function getLimit (limits, name, defaultLimit) {
+  if (
+    !limits ||
+    limits[name] === undefined ||
+    limits[name] === null
+  ) { return defaultLimit }
+
+  if (
+    typeof limits[name] !== 'number' ||
+    isNaN(limits[name])
+  ) { throw new TypeError('Limit ' + name + ' is not a valid number') }
+
+  return limits[name]
 }
 
 module.exports = HeaderParser


### PR DESCRIPTION
App Services in Atlas Triggers [does not support](https://www.mongodb.com/docs/atlas/app-services/functions/javascript-support/#util--) `util.TextDecoder`. As a result using `firebase-admin` (with `Dicer` through`@fastify/busboy`) on Atlas Triggers throws the errors reported in #100 and https://github.com/firebase/firebase-admin-node/issues/1902

Looking at the code, it doesn't look like `Dicer` has a direct dependency on `TextDecoder`. IIUC the dependency to `TextDecoder` comes from `libs/utils`, which is required in `deps/dicer/lib/HeaderParser.js` to access the util function `getLimit()`.

This PR removes the dependency to `lib/utils` from `deps/dicer/lib/HeaderParser.js` in turn removing the dependency to `TextDecoder`.

I simply copied the `getLimit()` to `HeaderParser.js`, but a better alternative would be to move `getLimit()` to it's own util file and import from there... that way we can keep a single implementation with single set of tests. It also seemed a bit of an overkill so I am proposing this first to see what you think. :)

[x] `npm run test`
[x] `npm run bench:dicer`

```
1612.90 mb/sec
1562.50 mb/sec
1470.59 mb/sec
1538.46 mb/sec
1219.51 mb/sec
1369.86 mb/sec
1333.33 mb/sec
1265.82 mb/sec
1351.35 mb/sec
1265.82 mb/sec
```

Resolves: #100 