### PR TITLE
remove text-decoding

### DIFF
--- a/lib/utils/decodeText.js
+++ b/lib/utils/decodeText.js
@@ -1,20 +1,11 @@
 'use strict'
 
-let TextDecoder
-try {
-  TextDecoder = require('util').TextDecoder
-} catch (e) { }
-
-const { TextDecoder: PolyfillTextDecoder, getEncoding } = require('text-decoding')
-
 // Node has always utf-8
-const textDecoders = new Map()
-if (TextDecoder) {
-  textDecoders.set('utf-8', new TextDecoder('utf-8'))
-} else {
-  textDecoders.set('utf-8', new PolyfillTextDecoder('utf-8'))
-}
-textDecoders.set('utf8', textDecoders.get('utf-8'))
+const utf8Decoder = new TextDecoder('utf-8')
+const textDecoders = new Map([
+  ['utf-8', utf8Decoder],
+  ['utf8', utf8Decoder]
+])
 
 function decodeText (text, textEncoding, destEncoding) {
   if (text) {
@@ -26,35 +17,10 @@ function decodeText (text, textEncoding, destEncoding) {
       try {
         textDecoders.set(destEncoding, new TextDecoder(destEncoding))
         return textDecoders.get(destEncoding).decode(Buffer.from(text, textEncoding))
-      } catch (e) {
-        if (getEncoding(destEncoding)) {
-          try {
-            textDecoders.set(destEncoding, new PolyfillTextDecoder(destEncoding))
-            return textDecoders.get(destEncoding).decode(Buffer.from(text, textEncoding))
-          } catch (e) { }
-        }
-      }
-    }
-  }
-  return text
-}
-
-function decodeTextPolyfill (text, textEncoding, destEncoding) {
-  if (text) {
-    if (textDecoders.has(destEncoding)) {
-      try {
-        return textDecoders.get(destEncoding).decode(Buffer.from(text, textEncoding))
       } catch (e) { }
-    } else {
-      if (getEncoding(destEncoding)) {
-        try {
-          textDecoders.set(destEncoding, new PolyfillTextDecoder(destEncoding))
-          return textDecoders.get(destEncoding).decode(Buffer.from(text, textEncoding))
-        } catch (e) { }
-      }
     }
   }
   return text
 }
 
-module.exports = TextDecoder ? decodeText : decodeTextPolyfill
+module.exports = decodeText

--- a/package.json
+++ b/package.json
@@ -34,9 +34,6 @@
   "engines": {
     "node": ">=14"
   },
-  "dependencies": {
-    "text-decoding": "^1.0.0"
-  },
   "devDependencies": {
     "@types/node": "^20.1.0",
     "busboy": "^1.0.0",


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

This was added in #50 for reasons I don't really understand. According to the PR node's TextDecoder is the fastest (and I assume it's even faster now), provides the same features, and is available globally since node v11.
