### PR TITLE
perf: use `node:` prefix to bypass require.cache call for builtins

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ Examples
 * Parsing (multipart) with default options:
 
 ```javascript
-const http = require('http');
-const { inspect } = require('util');
+const http = require('node:http');
+const { inspect } = require('node:util');
 const Busboy = require('busboy');
 
 http.createServer((req, res) => {
@@ -103,10 +103,10 @@ http.createServer((req, res) => {
 * Save all incoming files to disk:
 
 ```javascript
-const http = require('http');
-const path = require('path');
-const os = require('os');
-const fs = require('fs');
+const http = require('node:http');
+const path = require('node:path');
+const os = require('node:os');
+const fs = require('node:fs');
 
 const Busboy = require('busboy');
 
@@ -133,8 +133,8 @@ http.createServer(function(req, res) {
 * Parsing (urlencoded) with default options:
 
 ```javascript
-const http = require('http');
-const { inspect } = require('util');
+const http = require('node:http');
+const { inspect } = require('node:util');
 
 const Busboy = require('busboy');
 

--- a/bench/dicer/multiparty-bench-multipart-parser.js
+++ b/bench/dicer/multiparty-bench-multipart-parser.js
@@ -1,4 +1,4 @@
-var assert = require('assert'),
+var assert = require('node:assert'),
     Form = require('multiparty').Form,
     boundary = '-----------------------------168072824752491622650073',
     mb = 100,

--- a/bench/dicer/parted-bench-multipart-parser.js
+++ b/bench/dicer/parted-bench-multipart-parser.js
@@ -2,7 +2,7 @@
 // because otherwise it attempts to do some things above and beyond just parsing
 // -- like saving to disk and whatnot
 
-var assert = require('assert');
+var assert = require('node:assert');
 var Parser = require('./parted-multipart'),
     boundary = '-----------------------------168072824752491622650073',
     parser = new Parser('boundary=' + boundary),

--- a/bench/dicer/parted-multipart.js
+++ b/bench/dicer/parted-multipart.js
@@ -4,10 +4,10 @@
  * Copyright (c) 2011, Christopher Jeffrey. (MIT Licensed)
  */
 
-var fs = require('fs')
-  , path = require('path')
-  , EventEmitter = require('events').EventEmitter
-  , StringDecoder = require('string_decoder').StringDecoder
+var fs = require('node:fs')
+  , path = require('node:path')
+  , EventEmitter = require('node:events').EventEmitter
+  , StringDecoder = require('node:string_decoder').StringDecoder
   , set = require('qs').set
   , each = Array.prototype.forEach;
 

--- a/benchmarks/common/resultsCombinator.js
+++ b/benchmarks/common/resultsCombinator.js
@@ -1,5 +1,5 @@
-const fs = require('fs')
-const path = require('path')
+const fs = require('node:fs')
+const path = require('node:path')
 const getopts = require('getopts')
 const systemInformation = require('systeminformation')
 const { loadResults } = require('photofinish')

--- a/deps/dicer/lib/Dicer.js
+++ b/deps/dicer/lib/Dicer.js
@@ -1,7 +1,7 @@
 'use strict'
 
-const WritableStream = require('stream').Writable
-const inherits = require('util').inherits
+const WritableStream = require('node:stream').Writable
+const inherits = require('node:util').inherits
 
 const StreamSearch = require('../../streamsearch/sbmh')
 

--- a/deps/dicer/lib/HeaderParser.js
+++ b/deps/dicer/lib/HeaderParser.js
@@ -1,7 +1,7 @@
 'use strict'
 
-const EventEmitter = require('events').EventEmitter
-const inherits = require('util').inherits
+const EventEmitter = require('node:events').EventEmitter
+const inherits = require('node:util').inherits
 const getLimit = require('../../../lib/utils/getLimit')
 
 const StreamSearch = require('../../streamsearch/sbmh')

--- a/deps/dicer/lib/PartStream.js
+++ b/deps/dicer/lib/PartStream.js
@@ -1,7 +1,7 @@
 'use strict'
 
-const inherits = require('util').inherits
-const ReadableStream = require('stream').Readable
+const inherits = require('node:util').inherits
+const ReadableStream = require('node:stream').Readable
 
 function PartStream (opts) {
   ReadableStream.call(this, opts)

--- a/deps/streamsearch/sbmh.js
+++ b/deps/streamsearch/sbmh.js
@@ -26,8 +26,8 @@
  * Based heavily on the Streaming Boyer-Moore-Horspool C++ implementation
  * by Hongli Lai at: https://github.com/FooBarWidget/boyer-moore-horspool
  */
-const EventEmitter = require('events').EventEmitter
-const inherits = require('util').inherits
+const EventEmitter = require('node:events').EventEmitter
+const inherits = require('node:util').inherits
 
 function SBMH (needle) {
   if (typeof needle === 'string') {

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,7 +1,7 @@
 'use strict'
 
-const WritableStream = require('stream').Writable
-const { inherits } = require('util')
+const WritableStream = require('node:stream').Writable
+const { inherits } = require('node:util')
 const Dicer = require('../deps/dicer/lib/Dicer')
 
 const MultipartParser = require('./types/multipart')

--- a/lib/types/multipart.js
+++ b/lib/types/multipart.js
@@ -7,8 +7,8 @@
 //  * support limits.fieldNameSize
 //     -- this will require modifications to utils.parseParams
 
-const { Readable } = require('stream')
-const { inherits } = require('util')
+const { Readable } = require('node:stream')
+const { inherits } = require('node:util')
 
 const Dicer = require('../../deps/dicer/lib/Dicer')
 

--- a/test/dicer-multipart-extra-trailer.spec.js
+++ b/test/dicer-multipart-extra-trailer.spec.js
@@ -1,8 +1,8 @@
 const Dicer = require('../deps/dicer/lib/Dicer')
-const assert = require('assert')
-const fs = require('fs')
-const path = require('path')
-const inspect = require('util').inspect
+const assert = require('node:assert')
+const fs = require('node:fs')
+const path = require('node:path')
+const inspect = require('node:util').inspect
 
 const FIXTURES_ROOT = path.join(__dirname, 'fixtures/')
 

--- a/test/dicer-multipart-nolisteners.spec.js
+++ b/test/dicer-multipart-nolisteners.spec.js
@@ -1,8 +1,8 @@
 const Dicer = require('../deps/dicer/lib/Dicer')
-const assert = require('assert')
-const fs = require('fs')
-const path = require('path')
-const inspect = require('util').inspect
+const assert = require('node:assert')
+const fs = require('node:fs')
+const path = require('node:path')
+const inspect = require('node:util').inspect
 
 const FIXTURES_ROOT = path.join(__dirname, 'fixtures/')
 

--- a/test/dicer-multipart.spec.js
+++ b/test/dicer-multipart.spec.js
@@ -1,8 +1,8 @@
 const Dicer = require('../deps/dicer/lib/Dicer')
-const assert = require('assert')
-const fs = require('fs')
-const path = require('path')
-const inspect = require('util').inspect
+const assert = require('node:assert')
+const fs = require('node:fs')
+const path = require('node:path')
+const inspect = require('node:util').inspect
 
 const FIXTURES_ROOT = path.join(__dirname, 'fixtures/')
 

--- a/test/multipart-stream-pause.spec.js
+++ b/test/multipart-stream-pause.spec.js
@@ -1,4 +1,4 @@
-const { inspect } = require('util')
+const { inspect } = require('node:util')
 const { assert } = require('chai')
 const Busboy = require('..')
 

--- a/test/parse-params.spec.js
+++ b/test/parse-params.spec.js
@@ -1,4 +1,4 @@
-const { inspect } = require('util')
+const { inspect } = require('node:util')
 const { assert } = require('chai')
 const parseParams = require('../lib/utils/parseParams')
 

--- a/test/types-multipart.spec.js
+++ b/test/types-multipart.spec.js
@@ -1,6 +1,6 @@
 const Busboy = require('..')
 
-const { inspect } = require('util')
+const { inspect } = require('node:util')
 const { assert } = require('chai')
 
 const EMPTY_FN = function () {

--- a/test/types-urlencoded.spec.js
+++ b/test/types-urlencoded.spec.js
@@ -1,4 +1,4 @@
-const { inspect } = require('util')
+const { inspect } = require('node:util')
 const { assert } = require('chai')
 const Busboy = require('..')
 


### PR DESCRIPTION
See https://github.com/fastify/fastify-static/pull/407

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
