### PR TITLE
perf: refactor parts of StreamSearch

### DIFF
--- a/deps/streamsearch/sbmh.js
+++ b/deps/streamsearch/sbmh.js
@@ -148,15 +148,16 @@ class SBMH extends EventEmitter {
 
     // Lookbehind buffer is now empty. We only need to check if the
     // needle is in the haystack.
-    if (data.indexOf(needle, pos) !== -1) {
-      pos = data.indexOf(needle, pos)
+    pos = data.indexOf(needle, pos)
+
+    if (pos !== -1) {
       ++this.matches
       if (pos > 0) { this.emit('info', true, data, this._bufpos, pos) } else { this.emit('info', true) }
 
       return (this._bufpos = pos + needleLength)
-    } else {
-      pos = len - needleLength
     }
+
+    pos = len - needleLength
 
     // There was no match. If there's trailing haystack data that we cannot
     // match yet using the Boyer-Moore-Horspool algorithm (because the trailing

--- a/deps/streamsearch/sbmh.js
+++ b/deps/streamsearch/sbmh.js
@@ -152,14 +152,14 @@ class SBMH extends EventEmitter {
         // been processed and append the entire haystack
         // into it.
         const bytesToCutOff = this._lookbehind_size + pos
+
         if (bytesToCutOff > 0) {
           // The cut off data is guaranteed not to contain the needle.
           this.emit('info', false, this._lookbehind, 0, bytesToCutOff)
         }
 
-        this._lookbehind.copy(this._lookbehind, 0, bytesToCutOff,
-          this._lookbehind_size - bytesToCutOff)
         this._lookbehind_size -= bytesToCutOff
+        this._lookbehind.copy(this._lookbehind, 0, bytesToCutOff, this._lookbehind_size)
 
         data.copy(this._lookbehind, this._lookbehind_size)
         this._lookbehind_size += len

--- a/deps/streamsearch/sbmh.js
+++ b/deps/streamsearch/sbmh.js
@@ -27,8 +27,8 @@
  * by Hongli Lai at: https://github.com/FooBarWidget/boyer-moore-horspool
  */
 
-const EventEmitter = require('node:events').EventEmitter
-const inherits = require('node:util').inherits
+const { EventEmitter } = require('node:events')
+const { inherits } = require('node:util')
 
 function SBMH (needle) {
   if (typeof needle === 'string') {

--- a/deps/streamsearch/sbmh.js
+++ b/deps/streamsearch/sbmh.js
@@ -27,206 +27,201 @@
  * by Hongli Lai at: https://github.com/FooBarWidget/boyer-moore-horspool
  */
 
-const { EventEmitter } = require('node:events')
+const EventEmitter = require('node:events').EventEmitter
+const inherits = require('node:util').inherits
 
-class SBMH extends EventEmitter {
-  constructor (needle) {
-    super()
-
-    if (typeof needle === 'string') {
-      needle = Buffer.from(needle)
-    }
-
-    if (!Buffer.isBuffer(needle)) {
-      throw new TypeError('The needle has to be a String or a Buffer.')
-    }
-
-    const needleLength = needle.length
-
-    if (needleLength === 0) {
-      throw new Error('The needle cannot be an empty String/Buffer.')
-    }
-
-    if (needleLength > 256) {
-      throw new Error('The needle cannot have a length bigger than 256.')
-    }
-
-    this.maxMatches = Infinity
-    this.matches = 0
-
-    this._needle = needle
-    this._bufpos = 0
-    this._lookbehind_size = 0
-    this._lookbehind = Buffer.alloc(needleLength)
-    this._occ = new Array(256).fill(needleLength) // Initialize occurrence table.
-
-    // Populate occurrence table with analysis of the needle, ignoring last letter.
-    for (var i = 0; i < needleLength - 1; ++i) { // eslint-disable-line no-var
-      this._occ[needle[i]] = needleLength - 1 - i
-    }
+function SBMH (needle) {
+  if (typeof needle === 'string') {
+    needle = Buffer.from(needle)
   }
 
-  reset () {
-    this.matches = 0
-    this._bufpos = 0
-    this._lookbehind_size = 0
+  if (!Buffer.isBuffer(needle)) {
+    throw new TypeError('The needle has to be a String or a Buffer.')
   }
 
-  push (chunk, pos = 0) {
-    if (!Buffer.isBuffer(chunk)) {
-      chunk = Buffer.from(chunk, 'binary')
+  const needleLength = needle.length
+
+  if (needleLength === 0) {
+    throw new Error('The needle cannot be an empty String/Buffer.')
+  }
+
+  if (needleLength > 256) {
+    throw new Error('The needle cannot have a length bigger than 256.')
+  }
+
+  this.maxMatches = Infinity
+  this.matches = 0
+
+  this._occ = new Array(256)
+    .fill(needleLength) // Initialize occurrence table.
+  this._lookbehind_size = 0
+  this._needle = needle
+  this._bufpos = 0
+
+  this._lookbehind = Buffer.alloc(needleLength)
+
+  // Populate occurrence table with analysis of the needle,
+  // ignoring last letter.
+  for (var i = 0; i < needleLength - 1; ++i) { // eslint-disable-line no-var
+    this._occ[needle[i]] = needleLength - 1 - i
+  }
+}
+inherits(SBMH, EventEmitter)
+
+SBMH.prototype.reset = function () {
+  this._lookbehind_size = 0
+  this.matches = 0
+  this._bufpos = 0
+}
+
+SBMH.prototype.push = function (chunk, pos) {
+  if (!Buffer.isBuffer(chunk)) {
+    chunk = Buffer.from(chunk, 'binary')
+  }
+  const chlen = chunk.length
+  this._bufpos = pos || 0
+  let r
+  while (r !== chlen && this.matches < this.maxMatches) { r = this._sbmh_feed(chunk) }
+  return r
+}
+
+SBMH.prototype._sbmh_feed = function (data) {
+  const len = data.length
+  const needle = this._needle
+  const needleLength = needle.length
+  const lastNeedleChar = needle[needleLength - 1]
+
+  // Positive: points to a position in `data`
+  //           pos == 3 points to data[3]
+  // Negative: points to a position in the lookbehind buffer
+  //           pos == -2 points to lookbehind[lookbehind_size - 2]
+  let pos = -this._lookbehind_size
+  let ch
+
+  if (pos < 0) {
+    // Lookbehind buffer is not empty. Perform Boyer-Moore-Horspool
+    // search with character lookup code that considers both the
+    // lookbehind buffer and the current round's haystack data.
+    //
+    // Loop until
+    //   there is a match.
+    // or until
+    //   we've moved past the position that requires the
+    //   lookbehind buffer. In this case we switch to the
+    //   optimized loop.
+    // or until
+    //   the character to look at lies outside the haystack.
+    while (pos < 0 && pos <= len - needleLength) {
+      ch = this._sbmh_lookup_char(data, pos + needleLength - 1)
+
+      if (
+        ch === lastNeedleChar &&
+        this._sbmh_memcmp(data, pos, needleLength - 1)
+      ) {
+        this._lookbehind_size = 0
+        ++this.matches
+        this.emit('info', true)
+
+        return (this._bufpos = pos + needleLength)
+      }
+      pos += this._occ[ch]
     }
 
-    this._bufpos = pos
-
-    const chlen = chunk.length
-    let r
-    while (r !== chlen && this.matches < this.maxMatches) { r = this._sbmh_feed(chunk) }
-    return r
-  }
-
-  _sbmh_feed (data) {
-    const len = data.length
-    const needle = this._needle
-    const needleLength = needle.length
-    const lastNeedleChar = needle[needleLength - 1]
-
-    // Positive: points to a position in `data`
-    //           pos == 3 points to data[3]
-    // Negative: points to a position in the lookbehind buffer
-    //           pos == -2 points to lookbehind[lookbehind_size - 2]
-    let pos = -this._lookbehind_size
-    let ch
+    // No match.
 
     if (pos < 0) {
-      // Lookbehind buffer is not empty. Perform Boyer-Moore-Horspool
-      // search with character lookup code that considers both the
-      // lookbehind buffer and the current round's haystack data.
-      //
-      // Loop until
-      //   there is a match.
+      // There's too few data for Boyer-Moore-Horspool to run,
+      // so let's use a different algorithm to skip as much as
+      // we can.
+      // Forward pos until
+      //   the trailing part of lookbehind + data
+      //   looks like the beginning of the needle
       // or until
-      //   we've moved past the position that requires the
-      //   lookbehind buffer. In this case we switch to the
-      //   optimized loop.
-      // or until
-      //   the character to look at lies outside the haystack.
-      while (pos < 0 && pos <= len - needleLength) {
-        ch = this._sbmh_lookup_char(data, pos + needleLength - 1)
-
-        if (
-          ch === lastNeedleChar &&
-          this._sbmh_memcmp(data, pos, needleLength - 1)
-        ) {
-          this._lookbehind_size = 0
-          ++this.matches
-          this.emit('info', true)
-
-          return (this._bufpos = pos + needleLength)
-        }
-
-        pos += this._occ[ch]
-      }
-
-      // No match.
-
-      if (pos < 0) {
-        // There's too few data for Boyer-Moore-Horspool to run,
-        // so let's use a different algorithm to skip as much as
-        // we can.
-        // Forward pos until
-        //   the trailing part of lookbehind + data
-        //   looks like the beginning of the needle
-        // or until
-        //   pos == 0
-        while (pos < 0 && !this._sbmh_memcmp(data, pos, len - pos)) { ++pos }
-      }
-
-      if (pos >= 0) {
-        // Discard lookbehind buffer.
-        this.emit('info', false, this._lookbehind, 0, this._lookbehind_size)
-        this._lookbehind_size = 0
-      } else {
-        // Cut off part of the lookbehind buffer that has
-        // been processed and append the entire haystack
-        // into it.
-        const bytesToCutOff = this._lookbehind_size + pos
-
-        if (bytesToCutOff > 0) {
-          // The cut off data is guaranteed not to contain the needle.
-          this.emit('info', false, this._lookbehind, 0, bytesToCutOff)
-        }
-
-        this._lookbehind_size -= bytesToCutOff
-        this._lookbehind.copy(this._lookbehind, 0, bytesToCutOff, this._lookbehind_size)
-
-        data.copy(this._lookbehind, this._lookbehind_size)
-        this._lookbehind_size += len
-
-        this._bufpos = len
-        return len
-      }
+      //   pos == 0
+      while (pos < 0 && !this._sbmh_memcmp(data, pos, len - pos)) { ++pos }
     }
 
-    // Lookbehind buffer is now empty. We only need to check if the
-    // needle is in the haystack.
-    pos = data.indexOf(needle, pos + ((pos >= 0) * this._bufpos))
+    if (pos >= 0) {
+      // Discard lookbehind buffer.
+      this.emit('info', false, this._lookbehind, 0, this._lookbehind_size)
+      this._lookbehind_size = 0
+    } else {
+      // Cut off part of the lookbehind buffer that has
+      // been processed and append the entire haystack
+      // into it.
+      const bytesToCutOff = this._lookbehind_size + pos
+      if (bytesToCutOff > 0) {
+        // The cut off data is guaranteed not to contain the needle.
+        this.emit('info', false, this._lookbehind, 0, bytesToCutOff)
+      }
 
-    if (pos !== -1) {
-      ++this.matches
+      this._lookbehind.copy(this._lookbehind, 0, bytesToCutOff,
+        this._lookbehind_size - bytesToCutOff)
+      this._lookbehind_size -= bytesToCutOff
 
-      if (pos > 0) { this.emit('info', true, data, this._bufpos, pos) } else { this.emit('info', true) }
+      data.copy(this._lookbehind, this._lookbehind_size)
+      this._lookbehind_size += len
 
-      return (this._bufpos = pos + needleLength)
+      this._bufpos = len
+      return len
     }
+  }
 
-    pos = len - needleLength
+  // Lookbehind buffer is now empty. We only need to check if the
+  // needle is in the haystack.
+  pos = data.indexOf(needle, pos + ((pos >= 0) * this._bufpos))
 
-    // There was no match. If there's trailing haystack data that we cannot
-    // match yet using the Boyer-Moore-Horspool algorithm (because the trailing
-    // data is less than the needle size) then match using a modified
-    // algorithm that starts matching from the beginning instead of the end.
-    // Whatever trailing data is left after running this algorithm is added to
-    // the lookbehind buffer.
-    while (
-      pos < len &&
+  if (pos !== -1) {
+    ++this.matches
+    if (pos > 0) { this.emit('info', true, data, this._bufpos, pos) } else { this.emit('info', true) }
+    return (this._bufpos = pos + needleLength)
+  }
+
+  pos = len - needleLength
+
+  // There was no match. If there's trailing haystack data that we cannot
+  // match yet using the Boyer-Moore-Horspool algorithm (because the trailing
+  // data is less than the needle size) then match using a modified
+  // algorithm that starts matching from the beginning instead of the end.
+  // Whatever trailing data is left after running this algorithm is added to
+  // the lookbehind buffer.
+  while (
+    pos < len &&
+    (
+      data[pos] !== needle[0] ||
       (
-        data[pos] !== needle[0] ||
-        Buffer.compare(
+        (Buffer.compare(
           data.subarray(pos, pos + len - pos),
           needle.subarray(0, len - pos)
-        ) !== 0
+        ) !== 0)
       )
-    ) {
-      ++pos
-    }
-
-    if (pos < len) {
-      data.copy(this._lookbehind, 0, pos, pos + (len - pos))
-      this._lookbehind_size = len - pos
-    }
-
-    // Everything until pos is guaranteed not to contain needle data.
-    if (pos > 0) { this.emit('info', false, data, this._bufpos, pos < len ? pos : len) }
-
-    this._bufpos = len
-
-    return len
+    )
+  ) {
+    ++pos
+  }
+  if (pos < len) {
+    data.copy(this._lookbehind, 0, pos, pos + (len - pos))
+    this._lookbehind_size = len - pos
   }
 
-  _sbmh_lookup_char (data, pos) {
-    return pos < 0
-      ? this._lookbehind[this._lookbehind_size + pos]
-      : data[pos]
-  }
+  // Everything until pos is guaranteed not to contain needle data.
+  if (pos > 0) { this.emit('info', false, data, this._bufpos, pos < len ? pos : len) }
 
-  _sbmh_memcmp (data, pos, len) {
-    for (var i = 0; i < len; ++i) { // eslint-disable-line no-var
-      if (this._sbmh_lookup_char(data, pos + i) !== this._needle[i]) { return false }
-    }
+  this._bufpos = len
+  return len
+}
 
-    return true
+SBMH.prototype._sbmh_lookup_char = function (data, pos) {
+  return (pos < 0)
+    ? this._lookbehind[this._lookbehind_size + pos]
+    : data[pos]
+}
+
+SBMH.prototype._sbmh_memcmp = function (data, pos, len) {
+  for (var i = 0; i < len; ++i) { // eslint-disable-line no-var
+    if (this._sbmh_lookup_char(data, pos + i) !== this._needle[i]) { return false }
   }
+  return true
 }
 
 module.exports = SBMH

--- a/deps/streamsearch/sbmh.js
+++ b/deps/streamsearch/sbmh.js
@@ -155,9 +155,8 @@ SBMH.prototype._sbmh_feed = function (data) {
         this.emit('info', false, this._lookbehind, 0, bytesToCutOff)
       }
 
-      this._lookbehind.copy(this._lookbehind, 0, bytesToCutOff,
-        this._lookbehind_size - bytesToCutOff)
       this._lookbehind_size -= bytesToCutOff
+      this._lookbehind.copy(this._lookbehind, 0, bytesToCutOff, this._lookbehind_size)
 
       data.copy(this._lookbehind, this._lookbehind_size)
       this._lookbehind_size += len
@@ -212,7 +211,7 @@ SBMH.prototype._sbmh_feed = function (data) {
 }
 
 SBMH.prototype._sbmh_lookup_char = function (data, pos) {
-  return (pos < 0)
+  return pos < 0
     ? this._lookbehind[this._lookbehind_size + pos]
     : data[pos]
 }

--- a/deps/streamsearch/sbmh.js
+++ b/deps/streamsearch/sbmh.js
@@ -1,228 +1,203 @@
 'use strict'
 
-/**
- * Copyright Brian White. All rights reserved.
- *
- * @see https://github.com/mscdex/streamsearch
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to
- * deal in the Software without restriction, including without limitation the
- * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
- * sell copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
- * IN THE SOFTWARE.
- *
- * Based heavily on the Streaming Boyer-Moore-Horspool C++ implementation
- * by Hongli Lai at: https://github.com/FooBarWidget/boyer-moore-horspool
- */
-const EventEmitter = require('node:events').EventEmitter
-const inherits = require('node:util').inherits
+const { EventEmitter } = require('node:events')
 
-function SBMH (needle) {
-  if (typeof needle === 'string') {
-    needle = Buffer.from(needle)
-  }
-
-  if (!Buffer.isBuffer(needle)) {
-    throw new TypeError('The needle has to be a String or a Buffer.')
-  }
-
-  const needleLength = needle.length
-
-  if (needleLength === 0) {
-    throw new Error('The needle cannot be an empty String/Buffer.')
-  }
-
-  if (needleLength > 256) {
-    throw new Error('The needle cannot have a length bigger than 256.')
-  }
-
-  this.maxMatches = Infinity
-  this.matches = 0
-
-  this._occ = new Array(256)
-    .fill(needleLength) // Initialize occurrence table.
-  this._lookbehind_size = 0
-  this._needle = needle
-  this._bufpos = 0
-
-  this._lookbehind = Buffer.alloc(needleLength)
-
-  // Populate occurrence table with analysis of the needle,
-  // ignoring last letter.
-  for (var i = 0; i < needleLength - 1; ++i) { // eslint-disable-line no-var
-    this._occ[needle[i]] = needleLength - 1 - i
-  }
-}
-inherits(SBMH, EventEmitter)
-
-SBMH.prototype.reset = function () {
-  this._lookbehind_size = 0
-  this.matches = 0
-  this._bufpos = 0
-}
-
-SBMH.prototype.push = function (chunk, pos) {
-  if (!Buffer.isBuffer(chunk)) {
-    chunk = Buffer.from(chunk, 'binary')
-  }
-  const chlen = chunk.length
-  this._bufpos = pos || 0
-  let r
-  while (r !== chlen && this.matches < this.maxMatches) { r = this._sbmh_feed(chunk) }
-  return r
-}
-
-SBMH.prototype._sbmh_feed = function (data) {
-  const len = data.length
-  const needle = this._needle
-  const needleLength = needle.length
-  const lastNeedleChar = needle[needleLength - 1]
-
-  // Positive: points to a position in `data`
-  //           pos == 3 points to data[3]
-  // Negative: points to a position in the lookbehind buffer
-  //           pos == -2 points to lookbehind[lookbehind_size - 2]
-  let pos = -this._lookbehind_size
-  let ch
-
-  if (pos < 0) {
-    // Lookbehind buffer is not empty. Perform Boyer-Moore-Horspool
-    // search with character lookup code that considers both the
-    // lookbehind buffer and the current round's haystack data.
-    //
-    // Loop until
-    //   there is a match.
-    // or until
-    //   we've moved past the position that requires the
-    //   lookbehind buffer. In this case we switch to the
-    //   optimized loop.
-    // or until
-    //   the character to look at lies outside the haystack.
-    while (pos < 0 && pos <= len - needleLength) {
-      ch = this._sbmh_lookup_char(data, pos + needleLength - 1)
-
-      if (
-        ch === lastNeedleChar &&
-        this._sbmh_memcmp(data, pos, needleLength - 1)
-      ) {
-        this._lookbehind_size = 0
-        ++this.matches
-        this.emit('info', true)
-
-        return (this._bufpos = pos + needleLength)
-      }
-      pos += this._occ[ch]
+class SBMH extends EventEmitter {
+  constructor (needle) {
+    super()
+    if (typeof needle === 'string') {
+      needle = Buffer.from(needle)
     }
 
-    // No match.
+    if (!Buffer.isBuffer(needle)) {
+      throw new TypeError('The needle has to be a String or a Buffer.')
+    }
+
+    const needleLength = needle.length
+
+    if (needleLength === 0) {
+      throw new Error('The needle cannot be an empty String/Buffer.')
+    }
+
+    if (needleLength > 256) {
+      throw new Error('The needle cannot have a length bigger than 256.')
+    }
+
+    this.maxMatches = Infinity
+    this.matches = 0
+
+    this._occ = new Array(256)
+      .fill(needleLength) // Initialize occurrence table.
+    this._lookbehind_size = 0
+    this._needle = needle
+    this._bufpos = 0
+
+    this._lookbehind = Buffer.alloc(needleLength)
+
+    // Populate occurrence table with analysis of the needle,
+    // ignoring last letter.
+    for (var i = 0; i < needleLength - 1; ++i) { // eslint-disable-line no-var
+      this._occ[needle[i]] = needleLength - 1 - i
+    }
+  }
+
+  reset () {
+    this._lookbehind_size = 0
+    this.matches = 0
+    this._bufpos = 0
+  }
+
+  push (chunk, pos) {
+    if (!Buffer.isBuffer(chunk)) {
+      chunk = Buffer.from(chunk, 'binary')
+    }
+    const chlen = chunk.length
+    this._bufpos = pos || 0
+    let r
+    while (r !== chlen && this.matches < this.maxMatches) { r = this._sbmh_feed(chunk) }
+    return r
+  }
+
+  _sbmh_feed (data) {
+    const len = data.length
+    const needle = this._needle
+    const needleLength = needle.length
+    const lastNeedleChar = needle[needleLength - 1]
+
+    // Positive: points to a position in `data`
+    //           pos == 3 points to data[3]
+    // Negative: points to a position in the lookbehind buffer
+    //           pos == -2 points to lookbehind[lookbehind_size - 2]
+    let pos = -this._lookbehind_size
+    let ch
 
     if (pos < 0) {
-      // There's too few data for Boyer-Moore-Horspool to run,
-      // so let's use a different algorithm to skip as much as
-      // we can.
-      // Forward pos until
-      //   the trailing part of lookbehind + data
-      //   looks like the beginning of the needle
+      // Lookbehind buffer is not empty. Perform Boyer-Moore-Horspool
+      // search with character lookup code that considers both the
+      // lookbehind buffer and the current round's haystack data.
+      //
+      // Loop until
+      //   there is a match.
       // or until
-      //   pos == 0
-      while (pos < 0 && !this._sbmh_memcmp(data, pos, len - pos)) { ++pos }
-    }
+      //   we've moved past the position that requires the
+      //   lookbehind buffer. In this case we switch to the
+      //   optimized loop.
+      // or until
+      //   the character to look at lies outside the haystack.
+      while (pos < 0 && pos <= len - needleLength) {
+        ch = this._sbmh_lookup_char(data, pos + needleLength - 1)
 
-    if (pos >= 0) {
-      // Discard lookbehind buffer.
-      this.emit('info', false, this._lookbehind, 0, this._lookbehind_size)
-      this._lookbehind_size = 0
-    } else {
-      // Cut off part of the lookbehind buffer that has
-      // been processed and append the entire haystack
-      // into it.
-      const bytesToCutOff = this._lookbehind_size + pos
-      if (bytesToCutOff > 0) {
-        // The cut off data is guaranteed not to contain the needle.
-        this.emit('info', false, this._lookbehind, 0, bytesToCutOff)
+        if (
+          ch === lastNeedleChar &&
+          this._sbmh_memcmp(data, pos, needleLength - 1)
+        ) {
+          this._lookbehind_size = 0
+          ++this.matches
+          this.emit('info', true)
+
+          return (this._bufpos = pos + needleLength)
+        }
+        pos += this._occ[ch]
       }
 
-      this._lookbehind.copy(this._lookbehind, 0, bytesToCutOff,
-        this._lookbehind_size - bytesToCutOff)
-      this._lookbehind_size -= bytesToCutOff
+      // No match.
 
-      data.copy(this._lookbehind, this._lookbehind_size)
-      this._lookbehind_size += len
+      if (pos < 0) {
+        // There's too few data for Boyer-Moore-Horspool to run,
+        // so let's use a different algorithm to skip as much as
+        // we can.
+        // Forward pos until
+        //   the trailing part of lookbehind + data
+        //   looks like the beginning of the needle
+        // or until
+        //   pos == 0
+        while (pos < 0 && !this._sbmh_memcmp(data, pos, len - pos)) { ++pos }
+      }
 
-      this._bufpos = len
-      return len
+      if (pos >= 0) {
+        // Discard lookbehind buffer.
+        this.emit('info', false, this._lookbehind, 0, this._lookbehind_size)
+        this._lookbehind_size = 0
+      } else {
+        // Cut off part of the lookbehind buffer that has
+        // been processed and append the entire haystack
+        // into it.
+        const bytesToCutOff = this._lookbehind_size + pos
+        if (bytesToCutOff > 0) {
+          // The cut off data is guaranteed not to contain the needle.
+          this.emit('info', false, this._lookbehind, 0, bytesToCutOff)
+        }
+
+        this._lookbehind.copy(this._lookbehind, 0, bytesToCutOff,
+          this._lookbehind_size - bytesToCutOff)
+        this._lookbehind_size -= bytesToCutOff
+
+        data.copy(this._lookbehind, this._lookbehind_size)
+        this._lookbehind_size += len
+
+        this._bufpos = len
+        return len
+      }
     }
-  }
 
-  pos += (pos >= 0) * this._bufpos
+    pos += (pos >= 0) * this._bufpos
 
-  // Lookbehind buffer is now empty. We only need to check if the
-  // needle is in the haystack.
-  if (data.indexOf(needle, pos) !== -1) {
-    pos = data.indexOf(needle, pos)
-    ++this.matches
-    if (pos > 0) { this.emit('info', true, data, this._bufpos, pos) } else { this.emit('info', true) }
+    // Lookbehind buffer is now empty. We only need to check if the
+    // needle is in the haystack.
+    if (data.indexOf(needle, pos) !== -1) {
+      pos = data.indexOf(needle, pos)
+      ++this.matches
+      if (pos > 0) { this.emit('info', true, data, this._bufpos, pos) } else { this.emit('info', true) }
 
-    return (this._bufpos = pos + needleLength)
-  } else {
-    pos = len - needleLength
-  }
+      return (this._bufpos = pos + needleLength)
+    } else {
+      pos = len - needleLength
+    }
 
-  // There was no match. If there's trailing haystack data that we cannot
-  // match yet using the Boyer-Moore-Horspool algorithm (because the trailing
-  // data is less than the needle size) then match using a modified
-  // algorithm that starts matching from the beginning instead of the end.
-  // Whatever trailing data is left after running this algorithm is added to
-  // the lookbehind buffer.
-  while (
-    pos < len &&
-    (
-      data[pos] !== needle[0] ||
+    // There was no match. If there's trailing haystack data that we cannot
+    // match yet using the Boyer-Moore-Horspool algorithm (because the trailing
+    // data is less than the needle size) then match using a modified
+    // algorithm that starts matching from the beginning instead of the end.
+    // Whatever trailing data is left after running this algorithm is added to
+    // the lookbehind buffer.
+    while (
+      pos < len &&
       (
-        (Buffer.compare(
-          data.subarray(pos, pos + len - pos),
-          needle.subarray(0, len - pos)
-        ) !== 0)
+        data[pos] !== needle[0] ||
+        (
+          (Buffer.compare(
+            data.subarray(pos, pos + len - pos),
+            needle.subarray(0, len - pos)
+          ) !== 0)
+        )
       )
-    )
-  ) {
-    ++pos
+    ) {
+      ++pos
+    }
+    if (pos < len) {
+      data.copy(this._lookbehind, 0, pos, pos + (len - pos))
+      this._lookbehind_size = len - pos
+    }
+
+    // Everything until pos is guaranteed not to contain needle data.
+    if (pos > 0) { this.emit('info', false, data, this._bufpos, pos < len ? pos : len) }
+
+    this._bufpos = len
+    return len
   }
-  if (pos < len) {
-    data.copy(this._lookbehind, 0, pos, pos + (len - pos))
-    this._lookbehind_size = len - pos
+
+  _sbmh_lookup_char (data, pos) {
+    return (pos < 0)
+      ? this._lookbehind[this._lookbehind_size + pos]
+      : data[pos]
   }
 
-  // Everything until pos is guaranteed not to contain needle data.
-  if (pos > 0) { this.emit('info', false, data, this._bufpos, pos < len ? pos : len) }
-
-  this._bufpos = len
-  return len
-}
-
-SBMH.prototype._sbmh_lookup_char = function (data, pos) {
-  return (pos < 0)
-    ? this._lookbehind[this._lookbehind_size + pos]
-    : data[pos]
-}
-
-SBMH.prototype._sbmh_memcmp = function (data, pos, len) {
-  for (var i = 0; i < len; ++i) { // eslint-disable-line no-var
-    if (this._sbmh_lookup_char(data, pos + i) !== this._needle[i]) { return false }
+  _sbmh_memcmp (data, pos, len) {
+    for (var i = 0; i < len; ++i) { // eslint-disable-line no-var
+      if (this._sbmh_lookup_char(data, pos + i) !== this._needle[i]) { return false }
+    }
+    return true
   }
-  return true
 }
 
 module.exports = SBMH

--- a/deps/streamsearch/sbmh.js
+++ b/deps/streamsearch/sbmh.js
@@ -77,10 +77,9 @@ class SBMH extends EventEmitter {
       chunk = Buffer.from(chunk, 'binary')
     }
 
-    const chlen = chunk.length
-
     this._bufpos = pos
 
+    const chlen = chunk.length
     let r
     while (r !== chlen && this.matches < this.maxMatches) { r = this._sbmh_feed(chunk) }
     return r

--- a/deps/streamsearch/sbmh.js
+++ b/deps/streamsearch/sbmh.js
@@ -188,12 +188,10 @@ SBMH.prototype._sbmh_feed = function (data) {
     pos < len &&
     (
       data[pos] !== needle[0] ||
-      (
-        (Buffer.compare(
-          data.subarray(pos, pos + len - pos),
-          needle.subarray(0, len - pos)
-        ) !== 0)
-      )
+      Buffer.compare(
+        data.subarray(pos, pos + len - pos),
+        needle.subarray(0, len - pos)
+      ) !== 0
     )
   ) {
     ++pos

--- a/deps/streamsearch/sbmh.js
+++ b/deps/streamsearch/sbmh.js
@@ -170,12 +170,10 @@ class SBMH extends EventEmitter {
       pos < len &&
       (
         data[pos] !== needle[0] ||
-        (
-          (Buffer.compare(
-            data.subarray(pos, pos + len - pos),
-            needle.subarray(0, len - pos)
-          ) !== 0)
-        )
+        Buffer.compare(
+          data.subarray(pos, pos + len - pos),
+          needle.subarray(0, len - pos)
+        ) !== 0
       )
     ) {
       ++pos

--- a/deps/streamsearch/sbmh.js
+++ b/deps/streamsearch/sbmh.js
@@ -152,6 +152,7 @@ class SBMH extends EventEmitter {
 
     if (pos !== -1) {
       ++this.matches
+
       if (pos > 0) { this.emit('info', true, data, this._bufpos, pos) } else { this.emit('info', true) }
 
       return (this._bufpos = pos + needleLength)

--- a/deps/streamsearch/sbmh.js
+++ b/deps/streamsearch/sbmh.js
@@ -50,14 +50,12 @@ class SBMH extends EventEmitter {
       chunk = Buffer.from(chunk, 'binary')
     }
 
-    this._bufpos = pos
     const chlen = chunk.length
+
+    this._bufpos = pos
+
     let r
-
-    while (r !== chlen && this.matches < this.maxMatches) {
-      r = this._sbmh_feed(chunk)
-    }
-
+    while (r !== chlen && this.matches < this.maxMatches) { r = this._sbmh_feed(chunk) }
     return r
   }
 

--- a/deps/streamsearch/sbmh.js
+++ b/deps/streamsearch/sbmh.js
@@ -142,11 +142,9 @@ class SBMH extends EventEmitter {
       }
     }
 
-    pos += (pos >= 0) * this._bufpos
-
     // Lookbehind buffer is now empty. We only need to check if the
     // needle is in the haystack.
-    pos = data.indexOf(needle, pos)
+    pos = data.indexOf(needle, pos + ((pos >= 0) * this._bufpos))
 
     if (pos !== -1) {
       ++this.matches

--- a/deps/streamsearch/sbmh.js
+++ b/deps/streamsearch/sbmh.js
@@ -193,7 +193,7 @@ class SBMH extends EventEmitter {
   }
 
   _sbmh_lookup_char (data, pos) {
-    return (pos < 0)
+    return pos < 0
       ? this._lookbehind[this._lookbehind_size + pos]
       : data[pos]
   }

--- a/deps/streamsearch/sbmh.js
+++ b/deps/streamsearch/sbmh.js
@@ -68,8 +68,8 @@ class SBMH extends EventEmitter {
 
   reset () {
     this.matches = 0
-    this._lookbehind_size = 0
     this._bufpos = 0
+    this._lookbehind_size = 0
   }
 
   push (chunk, pos = 0) {

--- a/deps/streamsearch/sbmh.js
+++ b/deps/streamsearch/sbmh.js
@@ -5,6 +5,7 @@ const { EventEmitter } = require('node:events')
 class SBMH extends EventEmitter {
   constructor (needle) {
     super()
+
     if (typeof needle === 'string') {
       needle = Buffer.from(needle)
     }

--- a/deps/streamsearch/sbmh.js
+++ b/deps/streamsearch/sbmh.js
@@ -1,5 +1,32 @@
 'use strict'
 
+/**
+ * Copyright Brian White. All rights reserved.
+ *
+ * @see https://github.com/mscdex/streamsearch
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *
+ * Based heavily on the Streaming Boyer-Moore-Horspool C++ implementation
+ * by Hongli Lai at: https://github.com/FooBarWidget/boyer-moore-horspool
+ */
+
 const { EventEmitter } = require('node:events')
 
 class SBMH extends EventEmitter {


### PR DESCRIPTION
Goal: Modernize and improve this library as much possible starting with StreamSearch

Small improvements:

https://github.com/fastify/busboy/commit/a4e91c508f61dc45f8507e689280e51380a67317 — when we match, no need to calculate the pos again, let's just directly assign and check
https://github.com/fastify/busboy/commit/c281addf88a4f701af71f28d309fe802a8b23a70 — unnecessary allocation
https://github.com/fastify/busboy/commit/ca4602dc1f93ebb130b24ccdc92590b13eaffc01 — unnecessary subtraction