### PR TITLE
Improve test coverage

### DIFF
--- a/test/decoder.test.js
+++ b/test/decoder.test.js
@@ -17,6 +17,11 @@ test('Decoder', t => {
       what: 'One full encoded byte'
     },
     {
+      source: ['%20Hello World'],
+      expected: ' Hello World',
+      what: 'Start with full encoded byte'
+    },
+    {
       source: ['Hello%20world%21'],
       expected: 'Hello world!',
       what: 'Two full encoded bytes'

--- a/test/parse-params.test.js
+++ b/test/parse-params.test.js
@@ -52,6 +52,11 @@ test('parse-params', t => {
       what: 'Quotes within quoted'
     },
     {
+      source: 'text/plain; greeting="hello \\\\world\\\\"',
+      expected: ['text/plain', ['greeting', 'hello \\world\\']],
+      what: 'Escape within quoted'
+    },
+    {
       source: 'text/plain; encoding=""',
       expected: ['text/plain', ['encoding', '']],
       what: 'Quoted empty string'
@@ -85,6 +90,11 @@ test('parse-params', t => {
       source: "text/plain; filename*=iso-8859-1'en'%A3%20rates; altfilename=\"foobarbaz\"",
       expected: ['text/plain', ['filename', '£ rates'], ['altfilename', 'foobarbaz']],
       what: 'Mixed regular and extended parameters (RFC 5987)'
+    },
+    {
+      source: "text/plain; filename*=iso-8859-1'en';",
+      expected: ['text/plain', ['filename', '']],
+      what: 'Mixed regular and extended parameters (RFC 5987) with separator'
     },
     {
       source: "text/plain; filename=\"foobarbaz\"; altfilename*=iso-8859-1'en'%A3%20rates",

--- a/test/streamsearch.test.js
+++ b/test/streamsearch.test.js
@@ -4,7 +4,7 @@ const { test } = require('tap')
 const Streamsearch = require('../deps/streamsearch/sbmh')
 
 test('streamsearch', t => {
-  t.plan(17)
+  t.plan(18)
 
   t.test('should throw an error if the needle is not a String or Buffer', t => {
     t.plan(1)
@@ -316,6 +316,40 @@ test('streamsearch', t => {
       Buffer.from('\n'),
       Buffer.from('\n'),
       Buffer.from('hello')
+    ]
+    let i = 0
+    s.on('info', (isMatched, data, start, end) => {
+      t.strictSame(isMatched, expected[i][0])
+      t.strictSame(data, expected[i][1])
+      t.strictSame(start, expected[i][2])
+      t.strictSame(end, expected[i][3])
+      i++
+      if (i >= 3) {
+        t.pass()
+      }
+    })
+
+    s.push(chunks[0])
+    s.push(chunks[1])
+    s.push(chunks[2])
+    s.push(chunks[3])
+  })
+
+  t.test('should process four chunks with repeted starting overflowing needle', t => {
+    t.plan(13)
+
+    const expected = [
+      [false, Buffer.from('\n\n\0'), 0, 1],
+      [true, undefined, undefined, undefined],
+      [false, Buffer.from('\r\nhello'), 1, 7]
+    ]
+    const needle = '\n\n\r'
+    const s = new Streamsearch(needle)
+    const chunks = [
+      Buffer.from('\n'),
+      Buffer.from('\n'),
+      Buffer.from('\n'),
+      Buffer.from('\r\nhello')
     ]
     let i = 0
     s.on('info', (isMatched, data, start, end) => {

--- a/test/types-urlencoded.test.js
+++ b/test/types-urlencoded.test.js
@@ -239,7 +239,7 @@ tests.forEach((v) => {
   })
 })
 
-test('Call end twice', t => {
+test('Call parser end twice', t => {
   t.plan(1)
 
   let finishes = 0
@@ -257,4 +257,29 @@ test('Call end twice', t => {
 
   busboy._parser.end()
   busboy._parser.end()
+})
+
+test('Call emit finish twice', t => {
+  t.plan(2)
+
+  let fields = 0
+  let finishes = 0
+  
+  const busboy = new Busboy({
+    headers: {
+      'content-type': 'application/x-www-form-urlencoded; charset=utf-8'
+    }
+  })
+  busboy.on('field', function () {
+    t.ok(++fields === 1, 'field emitted')
+  })
+
+  busboy.on('finish', function () {
+    t.ok(++finishes === 1, 'finish emitted')
+  })
+
+  busboy.write(Buffer.from('Hello world', 'utf8'), EMPTY_FN)
+
+  busboy.emit('finish');
+  busboy.emit('finish');
 })

--- a/test/types-urlencoded.test.js
+++ b/test/types-urlencoded.test.js
@@ -264,7 +264,7 @@ test('Call emit finish twice', t => {
 
   let fields = 0
   let finishes = 0
-  
+
   const busboy = new Busboy({
     headers: {
       'content-type': 'application/x-www-form-urlencoded; charset=utf-8'
@@ -280,6 +280,6 @@ test('Call emit finish twice', t => {
 
   busboy.write(Buffer.from('Hello world', 'utf8'), EMPTY_FN)
 
-  busboy.emit('finish');
-  busboy.emit('finish');
+  busboy.emit('finish')
+  busboy.emit('finish')
 })

--- a/test/types-urlencoded.test.js
+++ b/test/types-urlencoded.test.js
@@ -28,6 +28,13 @@ const tests = [
     plan: 5
   },
   {
+    source: ['foo&baz=bla'],
+    expected: [['foo', '', false, false]],
+    what: 'Unassigned and assigned value with limit',
+    limits: { fields: 1 },
+    plan: 4
+  },
+  {
     source: ['foo=bar&baz'],
     expected: [['foo', 'bar', false, false],
       ['baz', '', false, false]],
@@ -81,6 +88,13 @@ const tests = [
     plan: 5
   },
   {
+    source: ['foo=bar&baz=bla', 'foo=bar'],
+    expected: [],
+    what: 'Exceeded limits',
+    limits: { fields: 0 },
+    plan: 3
+  },
+  {
     source: ['foo=bar&baz=bla'],
     expected: [],
     what: 'Limits: zero fields',
@@ -108,6 +122,22 @@ const tests = [
       ['ba', 'bla', true, false]],
     what: 'Limits: truncated field name',
     limits: { fieldNameSize: 2 },
+    plan: 5
+  },
+  {
+    source: ['f%20=bar&baz=bla'],
+    expected: [['f ', 'bar', false, false],
+      ['ba', 'bla', true, false]],
+    what: 'Limits: truncated field name with encoded bytes',
+    limits: { fieldNameSize: 2 },
+    plan: 5
+  },
+  {
+    source: ['foo=b%20&baz=bla'],
+    expected: [['foo', 'b ', false, false],
+      ['baz', 'bl', false, true]],
+    what: 'Limits: truncated field value with encoded bytes',
+    limits: { fieldSize: 2 },
     plan: 5
   },
   {
@@ -207,4 +237,24 @@ tests.forEach((v) => {
     })
     busboy.end()
   })
+})
+
+test('Call end twice', t => {
+  t.plan(1)
+
+  let finishes = 0
+  const busboy = new Busboy({
+    headers: {
+      'content-type': 'application/x-www-form-urlencoded; charset=utf-8'
+    }
+  })
+
+  busboy.on('finish', function () {
+    t.ok(++finishes === 1, 'finish emitted')
+  })
+
+  busboy.write(Buffer.from('Hello world', 'utf8'), EMPTY_FN)
+
+  busboy._parser.end()
+  busboy._parser.end()
 })


### PR DESCRIPTION
To help obtain 100% coverage from #126, I've added few tests. Also, few comments on some files that are still not 100% covered:

- `decodeText.js` still misses line 97 and 98. Though, I'm not sure they will ever be hit:
  1.  `this` keyword at line 96 is used, but the method is an arrow function which is called via `bind(charset)` from line 42; though, I'm afraid that, being an arrow function, the scope of the `this` inside of it will not be the passed value of `charset`
  2. Supposing we change from an arrow function to a function, I don't see how the `if` statement at line 96 will pass: we ask if the `textDecoders` has the given `charset`, where `textDecoders` includes `utf-8` and `utf8`. But, if the `charset` passed at line 42 is one of the two values, then another branch of the `switch` statement is taken.

- `urlencoded.js` still misses line 118 and 164, but again, I'm not sure that they will ever be hit.
  - In order to not enter the `if` statement at line 118, `p` needs to be higher than `len`, and the only way I figured out is the loop `for` at line 58, where inside at line 59 we have `if (!this._checkingBytes) { ++p }`
  - In order to enter this last `if`, `this._checkingBytes` must be `false`, which happens at line 112, which is inside an `else if (this._hitLimit)`
  - Thus, I need `this._hitlimit` equals to `true`, but.. If that happens, since that `if else` statement is before the last `else` at line 117 which leads to line 118, the line 118 cannot be reached with `p` being greater or equals to `len`
  - For what concern line 164, the reasoning is basically the same, since the only difference is that, for line 164, we are working on the parameter value, while for line 118 we are working for the parameter name

Of course, I may be wrong for both files: I tried to go through all the code and understanding it, but maybe I'm missing some pieces.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
