### PR TITLE
Pull `TextDecoder` from `util` explicitly.

### DIFF
--- a/lib/utils/decodeText.js
+++ b/lib/utils/decodeText.js
@@ -1,6 +1,7 @@
 'use strict'
 
-// Node has always utf-8
+const {TextDecoder} = require('util');
+
 const utf8Decoder = new TextDecoder('utf-8')
 const textDecoders = new Map([
   ['utf-8', utf8Decoder],


### PR DESCRIPTION
#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
