### PR TITLE
fix: lower lookbehind size to needleLength - 1

### DIFF
--- a/deps/streamsearch/sbmh.js
+++ b/deps/streamsearch/sbmh.js
@@ -40,6 +40,7 @@ function SBMH (needle) {
   }
 
   const needleLength = needle.length
+  const needleLastCharIndex = needleLength - 1
 
   if (needleLength === 0) {
     throw new Error('The needle cannot be an empty String/Buffer.')
@@ -58,12 +59,12 @@ function SBMH (needle) {
   this._needle = needle
   this._bufpos = 0
 
-  this._lookbehind = Buffer.alloc(needleLength - 1)
+  this._lookbehind = Buffer.alloc(needleLastCharIndex)
 
   // Populate occurrence table with analysis of the needle,
   // ignoring last letter.
-  for (var i = 0; i < needleLength - 1; ++i) { // eslint-disable-line no-var
-    this._occ[needle[i]] = needleLength - 1 - i
+  for (var i = 0; i < needleLastCharIndex; ++i) { // eslint-disable-line no-var
+    this._occ[needle[i]] = needleLastCharIndex - i
   }
 }
 inherits(SBMH, EventEmitter)

--- a/deps/streamsearch/sbmh.js
+++ b/deps/streamsearch/sbmh.js
@@ -58,7 +58,7 @@ function SBMH (needle) {
   this._needle = needle
   this._bufpos = 0
 
-  this._lookbehind = Buffer.alloc(needleLength)
+  this._lookbehind = Buffer.alloc(needleLength - 1)
 
   // Populate occurrence table with analysis of the needle,
   // ignoring last letter.

--- a/test/streamsearch.test.js
+++ b/test/streamsearch.test.js
@@ -244,7 +244,7 @@ test('streamsearch', async t => {
 
     const expected = [
       [false, Buffer.from('bar\r'), 0, 3],
-      [false, Buffer.from('\r\0\0'), 0, 1],
+      [false, Buffer.from('\r\0'), 0, 1],
       [false, Buffer.from('\n\r\nhello'), 0, 8]
     ]
     const needle = '\r\n\n'
@@ -339,7 +339,7 @@ test('streamsearch', async t => {
     t.plan(13)
 
     const expected = [
-      [false, Buffer.from('\n\n\0'), 0, 1],
+      [false, Buffer.from('\n\n'), 0, 1],
       [true, undefined, undefined, undefined],
       [false, Buffer.from('\r\nhello'), 1, 7]
     ]
@@ -374,8 +374,8 @@ test('streamsearch', async t => {
 
     const expected = [
       [false, Buffer.from('bar\r'), 0, 3],
-      [false, Buffer.from('\r\n\0'), 0, 2],
-      [false, Buffer.from('\r\n\0'), 0, 1],
+      [false, Buffer.from('\r\n'), 0, 2],
+      [false, Buffer.from('\r\n'), 0, 1],
       [false, Buffer.from('hello'), 0, 5]
     ]
     const needle = '\r\n\n'


### PR DESCRIPTION
lookbehind size doesn't need to be the same size as the needle, the last index is never used

Here's why: if it reaches the needle size with an incoming buffer, we immediately check and empty it anyway, we never store data that has enough length to be compared to the needle, it always has to be at max 1 less, otherwise the check would happen -- it's one of the guarantees of the algorithm

The test changes break nothing, we just had to change lookbehind length in expected checks