### PR TITLE
perf: make _occ Uint8Array

### DIFF
--- a/deps/streamsearch/sbmh.js
+++ b/deps/streamsearch/sbmh.js
@@ -52,7 +52,7 @@ function SBMH (needle) {
   this.maxMatches = Infinity
   this.matches = 0
 
-  this._occ = new Array(256)
+  this._occ = new Uint8Array(256)
     .fill(needleLength) // Initialize occurrence table.
   this._lookbehind_size = 0
   this._needle = needle


### PR DESCRIPTION
`needle` is a buffer, and _occ only takes buffer values (0-255), so it's more optimized (memory wise) to use an immutable Uint8Array here

Bench (node 22):

pr:
```sh
> busboy-benchmarks@1.0.0 benchmark-fastify
> node busboy/executioner.js -c 1

Mean time for fastify-busboy is 165742.53108811888 nanoseconds
all done
```

master:
```sh
> busboy-benchmarks@1.0.0 benchmark-fastify
> node busboy/executioner.js -c 1

Mean time for fastify-busboy is 166201.7394516819 nanoseconds
all done
```