### PR TITLE
perf: always check data when looking for last char of needle

### DIFF
--- a/deps/streamsearch/sbmh.js
+++ b/deps/streamsearch/sbmh.js
@@ -114,7 +114,7 @@ SBMH.prototype._sbmh_feed = function (data) {
     // or until
     //   the character to look at lies outside the haystack.
     while (pos < 0 && pos <= len - needleLength) {
-      ch = this._sbmh_lookup_char(data, pos + needleLastCharIndex)
+      ch = data[pos + needleLastCharIndex]
 
       if (
         ch === needleLastChar &&

--- a/test/streamsearch.test.js
+++ b/test/streamsearch.test.js
@@ -4,7 +4,7 @@ const { test } = require('node:test')
 const Streamsearch = require('../deps/streamsearch/sbmh')
 
 test('streamsearch', async t => {
-  t.plan(18)
+  t.plan(19)
 
   await t.test('should throw an error if the needle is not a String or Buffer', t => {
     t.plan(1)
@@ -231,6 +231,34 @@ test('streamsearch', async t => {
       t.assert.deepStrictEqual(end, expected[i][3])
       i++
       if (i >= 3) {
+        t.assert.ok('pass')
+      }
+    })
+
+    s.push(chunks[0])
+    s.push(chunks[1])
+  })
+
+  await t.test('should process two chunks with an overflowing needle /2', t => {
+    t.plan(9)
+    const expected = [
+      [false, Buffer.from('t\0\0'), 0, 1],
+      [false, Buffer.from('shello'), 0, 7]
+    ]
+    const needle = 'test'
+    const s = new Streamsearch(needle)
+    const chunks = [
+      Buffer.from('t'),
+      Buffer.from('eshello')
+    ]
+    let i = 0
+    s.on('info', (isMatched, data, start, end) => {
+      t.assert.deepStrictEqual(isMatched, expected[i][0])
+      t.assert.deepStrictEqual(data, expected[i][1])
+      t.assert.deepStrictEqual(start, expected[i][2])
+      t.assert.deepStrictEqual(end, expected[i][3])
+      i++
+      if (i >= 2) {
         t.assert.ok('pass')
       }
     })

--- a/test/streamsearch.test.js
+++ b/test/streamsearch.test.js
@@ -243,7 +243,7 @@ test('streamsearch', async t => {
     t.plan(9)
     const expected = [
       [false, Buffer.from('t\0\0'), 0, 1],
-      [false, Buffer.from('shello'), 0, 7]
+      [false, Buffer.from('eshello'), 0, 7]
     ]
     const needle = 'test'
     const s = new Streamsearch(needle)


### PR DESCRIPTION
Forgot this one

Since we've now established that:

- The lookbehind length is at max `needleLength - 1`, we have in the beginning `pos = -lookbehind_size >= -(needleLength - 1)`
- And since we start by checking the last character, that last char will always be in `data` as `pos + needleLength - 1 >= 0`, and pos values equal to and larger than 0 correspond to the incoming data rather than the lookbehind, so we can safely remove the method

In short, `ch` will always be in `data`