### PR TITLE
perf: use `node:` prefix to bypass require.cache call for builtins

### DIFF
--- a/lib/main.d.ts
+++ b/lib/main.d.ts
@@ -4,8 +4,8 @@
 
 /// <reference types="node" />
 
-import * as http from 'http';
-import { Readable, Writable } from 'stream';
+import * as http from 'node:http';
+import { Readable, Writable } from 'node:stream';
 export { Dicer } from "../deps/dicer/lib/dicer";
 
 export const Busboy: BusboyConstructor;

--- a/test/dicer-multipart-extra-trailer.test.js
+++ b/test/dicer-multipart-extra-trailer.test.js
@@ -2,8 +2,8 @@
 
 const { test } = require('node:test')
 const Dicer = require('../deps/dicer/lib/Dicer')
-const fs = require('fs')
-const path = require('path')
+const fs = require('node:fs')
+const path = require('node:path')
 
 const FIXTURES_ROOT = path.join(__dirname, 'fixtures/')
 

--- a/test/dicer-multipart-nolisteners.test.js
+++ b/test/dicer-multipart-nolisteners.test.js
@@ -2,8 +2,8 @@
 
 const Dicer = require('../deps/dicer/lib/Dicer')
 const { test } = require('node:test')
-const fs = require('fs')
-const path = require('path')
+const fs = require('node:fs')
+const path = require('node:path')
 
 const FIXTURES_ROOT = path.join(__dirname, 'fixtures/')
 

--- a/test/multipart-stream-pause.test.js
+++ b/test/multipart-stream-pause.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { inspect } = require('util')
+const { inspect } = require('node:util')
 const { test } = require('node:test')
 
 const Busboy = require('..')

--- a/test/types-multipart.test.js
+++ b/test/types-multipart.test.js
@@ -3,7 +3,7 @@
 const Busboy = require('..')
 
 const { test } = require('node:test')
-const { inspect } = require('util')
+const { inspect } = require('node:util')
 
 const EMPTY_FN = function () {
 }

--- a/test/types-urlencoded.test.js
+++ b/test/types-urlencoded.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { inspect } = require('util')
+const { inspect } = require('node:util')
 const Busboy = require('..')
 const { test } = require('node:test')
 


### PR DESCRIPTION
This is a batch PR, so may have some issues. Please review changes.