### PR TITLE
fix: enforce RFC 2183/7578 compliance for quoted Content-Disposition parameters

### DIFF
--- a/lib/utils/parseParams.js
+++ b/lib/utils/parseParams.js
@@ -136,6 +136,11 @@ function parseParams (str) {
         if (inquote) {
           inquote = false
           state = STATE_KEY
+          // Skip any remaining characters until we hit a semicolon or end of string
+          // This ensures we don't include characters after the closing quote
+          while (i + 1 < len && str[i + 1] !== ';') {
+            ++i
+          }
         } else { inquote = true }
         continue
       } else { escaping = false }

--- a/test/parse-params.test.js
+++ b/test/parse-params.test.js
@@ -115,6 +115,21 @@ test('parse-params', async t => {
       source: 'multipart/form-data; charset=utf-8; boundary=0xKhTmLbOuNdArY',
       expected: ['multipart/form-data', ['charset', 'utf-8'], ['boundary', '0xKhTmLbOuNdArY']],
       what: 'Multiple non-quoted parameters'
+    },
+    {
+      source: 'form-data; name="file"; filename="payload.jpg".html',
+      expected: ['form-data', ['name', 'file'], ['filename', 'payload.jpg']],
+      what: 'Improperly quoted filename should stop at closing quote (RFC 2183/7578 compliance)'
+    },
+    {
+      source: 'form-data; name="field"; filename="test.pdf"extra.txt',
+      expected: ['form-data', ['name', 'field'], ['filename', 'test.pdf']],
+      what: 'Quoted filename with trailing unquoted text should stop at closing quote'
+    },
+    {
+      source: 'text/plain; charset="utf-8"garbage; boundary=test',
+      expected: ['text/plain', ['charset', 'utf-8'], ['boundary', 'test']],
+      what: 'Quoted parameter with trailing garbage should stop at closing quote'
     }
   ]
 


### PR DESCRIPTION
## Summary
- Fixes improper parsing of Content-Disposition filename parameters that violates RFC 2183 and RFC 7578
- Ensures quoted parameter values stop at the closing quote instead of continuing to parse trailing characters
- Prevents security issues where `filename="payload.jpg".html` was incorrectly parsed as `payload.jpg.html` instead of `payload.jpg`

## Test plan
- [x] Added test cases to reproduce the issue
- [x] Verified the fix correctly handles improperly quoted filenames
- [x] Ensured all existing tests continue to pass
- [x] Added additional edge case tests for robustness