### PR TITLE
chore: restore to neostandard v0.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "photofinish": "^1.8.0",
     "snazzy": "^9.0.0",
     "eslint": "^9.39.0",
-    "neostandard": "^0.13.0",
+    "neostandard": "^0.12.0",
     "tinybench": "^6.0.0",
     "tstyche": "^7.0.0",
     "tslib": "^2.8.1",


### PR DESCRIPTION
Proposal:

- Restore `neostandard` to `^0.12.0`
- Fixes this error when running the `npm run lint` command                  
                                          
<img width="1181" height="194" alt="screenshot-error" src="https://github.com/user-attachments/assets/f70d0577-44bb-4be5-8537-cdaf5826020a" />



so that we can merge this PR as well: https://github.com/fastify/busboy/pull/212