### PR TITLE
chore: return to typescript v6.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,6 +34,7 @@ updates:
       - dependency-name: "eslint"
       - dependency-name: "neostandard"
       - dependency-name: "@stylistic/*"
+      - dependency-name: "typescript"
     open-pull-requests-limit: 10
     groups:
       # Production dependencies with breaking changes

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "tinybench": "^6.0.0",
     "tstyche": "^7.0.0",
     "tslib": "^2.8.1",
-    "typescript": "~7.0.2"
+    "typescript": "~6.0.2"
   },
   "keywords": [
     "uploads",


### PR DESCRIPTION
Proposal:

I updated the TypeScript dependency to version 6.x, because `dependabot` had updated the TypeScript dependency version to version 7.x, but this caused an error in lint since `eslint` v9 and `neostandard` are not compatible yet, making the pipeline red.
Despite the CI being red, see here: https://github.com/fastify/busboy/pull/220/changes/48584195c624c17d01247316dac0f092d027b8a2 and https://github.com/fastify/busboy/actions/runs/29655747873/job/88109667826#step:5:1 dependabot merged the PR automatically.

Currently, major or automated updates to TypeScript can introduce breaking changes or type mismatches with our current linting setup (specifically with `eslint`, `neostandard`, and related plugins like `ts-api-utils`), causing commands like `npm run lint:fix` to fail with runtime type errors.

By ignoring it for now, we ensure that TypeScript updates are handled manually and verified alongside the rest of the linting toolchain.


cc @fastify/leads @fastify/libraries 